### PR TITLE
Debounce messages

### DIFF
--- a/assets/js/components/devices/DeviceIndex.jsx
+++ b/assets/js/components/devices/DeviceIndex.jsx
@@ -7,7 +7,6 @@ import RandomDeviceButton from './RandomDeviceButton'
 import DevicesTable from './DevicesTable'
 import DashboardLayout from '../common/DashboardLayout'
 import BlankSlate from '../common/BlankSlate'
-import {displayInfo} from '../../util/messages'
 
 // MUI
 import Button from 'material-ui/Button'
@@ -18,14 +17,6 @@ class DeviceIndex extends Component {
   componentDidMount() {
     const { fetchDevices } = this.props
     fetchDevices()
-    displayInfo("hello there")
-    displayInfo("hello there")
-    displayInfo("hello there")
-    displayInfo("hello there")
-    displayInfo("hello there")
-    displayInfo("hi there")
-
-    setTimeout(() => displayInfo("hello there"), 500)
   }
 
   render() {


### PR DESCRIPTION
Prevent showing the same message more than once every 300ms. This currently happens when requests that occur in parallel all fail for the same reason (e.g. your session token has expired)