### PR TITLE
router API for devices w/ channels

### DIFF
--- a/lib/console/devices/devices.ex
+++ b/lib/console/devices/devices.ex
@@ -36,6 +36,8 @@ defmodule Console.Devices do
 
   """
   def get_device!(id), do: Repo.get!(Device, id)
+  def get_device(id), do: Repo.get(Device, id)
+  def get_by_mac(mac), do: Repo.get_by(Device, mac: mac)
 
   def fetch_assoc(%Device{} = device, assoc \\ [:events, :team]) do
     Repo.preload(device, assoc)

--- a/lib/console/groups/groups.ex
+++ b/lib/console/groups/groups.ex
@@ -11,6 +11,8 @@ defmodule Console.Groups do
   alias Console.Channels.Channel
   alias Console.Teams.Team
 
+  def get_group!(id), do: Repo.get!(Group, id)
+
   def create_group(%Team{} = team, attrs \\ %{}) do
     attrs = Map.merge(attrs, %{team_id: team.id})
 

--- a/lib/console_web/controllers/router/device_controller.ex
+++ b/lib/console_web/controllers/router/device_controller.ex
@@ -1,0 +1,28 @@
+defmodule ConsoleWeb.Router.DeviceController do
+  use ConsoleWeb, :controller
+  import ConsoleWeb.AuthErrorHandler
+
+  alias Console.Devices
+  alias Console.Devices.Device
+
+  def show(conn, %{"id" => id_or_mac}) do
+    if String.length(id_or_mac) == 36 do
+      id = id_or_mac
+      with %Device{} = device = Devices.get_device(id) do
+        conn |> show_device(device)
+      end
+    else
+      mac = id_or_mac
+      with %Device{} = device = Devices.get_by_mac(mac) do
+        conn |> show_device(device)
+      end
+    end
+  end
+
+  defp show_device(conn, device) do
+    device = device |> Devices.fetch_assoc([:channels])
+
+    conn
+    |> render("show.json", device: device)
+  end
+end

--- a/lib/console_web/router.ex
+++ b/lib/console_web/router.ex
@@ -55,6 +55,8 @@ defmodule ConsoleWeb.Router do
     pipe_through ConsoleWeb.RouterApiPipeline
 
     get "/secret", SessionController, :secret
+
+    resources "/devices", DeviceController, only: [:show]
   end
 
   if Mix.env == :dev do

--- a/lib/console_web/views/router/channel_view.ex
+++ b/lib/console_web/views/router/channel_view.ex
@@ -1,0 +1,32 @@
+defmodule ConsoleWeb.Router.ChannelView do
+  use ConsoleWeb, :view
+  alias ConsoleWeb.Router.ChannelView
+
+  def render("index.json", %{channels: channels}) do
+    render_many(channels, ChannelView, "channel.json")
+  end
+
+  def render("show.json", %{channel: channel}) do
+    render_one(channel, ChannelView, "channel.json")
+  end
+
+  def render("channel.json", %{channel: channel}) do
+    %{
+      id: channel.id,
+      name: channel.name,
+      type: channel.type,
+      credentials: channel.credentials,
+      active: channel.active,
+      team_id: channel.team_id
+    }
+  end
+
+  def append_channels(json, channels) do
+    if Ecto.assoc_loaded?(channels) do
+      channels_json = render_many(channels, ChannelView, "channel.json")
+      Map.put(json, :channels, channels_json)
+    else
+      json
+    end
+  end
+end

--- a/lib/console_web/views/router/device_view.ex
+++ b/lib/console_web/views/router/device_view.ex
@@ -1,0 +1,23 @@
+defmodule ConsoleWeb.Router.DeviceView do
+  use ConsoleWeb, :view
+  alias ConsoleWeb.Router.DeviceView
+  alias ConsoleWeb.Router.ChannelView
+
+  def render("index.json", %{devices: devices}) do
+    render_many(devices, DeviceView, "device.json")
+  end
+
+  def render("show.json", %{device: device}) do
+    render_one(device, DeviceView, "device.json")
+  end
+
+  def render("device.json", %{device: device}) do
+    %{
+      id: device.id,
+      name: device.name,
+      mac: device.mac,
+      team_id: device.team_id
+    }
+    |> ChannelView.append_channels(device.channels)
+  end
+end


### PR DESCRIPTION
GET `/api/routers/devices/:id_or_mac`

returns details for a device given either its ID or MAC. Includes an array of all channels device shares a group with