### PR TITLE
Paginated devices index

### DIFF
--- a/assets/js/components/devices/DeviceIndex.jsx
+++ b/assets/js/components/devices/DeviceIndex.jsx
@@ -2,12 +2,16 @@ import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { fetchDevices, deleteDevice } from '../../actions/device'
+import { deleteDevice } from '../../actions/device'
 import RandomDeviceButton from './RandomDeviceButton'
 import DevicesTable from './DevicesTable'
 import DashboardLayout from '../common/DashboardLayout'
 import BlankSlate from '../common/BlankSlate'
 import userCan from '../../util/abilities'
+
+// GraphQL
+import { graphql } from 'react-apollo';
+import gql from 'graphql-tag';
 
 // MUI
 import Button from '@material-ui/core/Button'
@@ -15,26 +19,65 @@ import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 
 class DeviceIndex extends Component {
-  componentDidMount() {
-    const { fetchDevices } = this.props
-    fetchDevices()
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      page: 1,
+      pageSize: 10
+    }
+
+    this.handleChangePage = this.handleChangePage.bind(this)
+    this.handleChangeRowsPerPage = this.handleChangeRowsPerPage.bind(this)
+  }
+
+  handleChangeRowsPerPage(pageSize) {
+    this.setState({ pageSize, page: 1 })
+    const { fetchMore } = this.props.data
+
+    fetchMore({
+      variables: { page: 1, pageSize },
+      updateQuery: (prev, { fetchMoreResult }) => fetchMoreResult
+    })
+  }
+
+  handleChangePage(page) {
+    this.setState({ page })
+    const { fetchMore } = this.props.data
+    const { pageSize } = this.state
+
+    fetchMore({
+      variables: { page, pageSize },
+      updateQuery: (prev, { fetchMoreResult }) => fetchMoreResult
+    })
   }
 
   render() {
-    const { devices, deleteDevice } = this.props
+    const { deleteDevice } = this.props
+    const { loading, devices } = this.props.data
+
+    if (loading) return <DashboardLayout title={"All Devices"} />
 
     return(
       <DashboardLayout title={"All Devices"}>
         <Paper>
         </Paper>
         <Paper>
-          {devices.length === 0 ? (
+          {devices.entries.length === 0 ? (
             <BlankSlate
               title="No devices"
               subheading="To create a new device, click the red button in the corner"
             />
           ) : (
-            <DevicesTable devices={devices} deleteDevice={deleteDevice} />
+            <DevicesTable
+              devices={devices.entries}
+              deleteDevice={deleteDevice}
+              totalEntries={devices.totalEntries}
+              page={this.state.page}
+              pageSize={this.state.pageSize}
+              handleChangePage={this.handleChangePage}
+              handleChangeRowsPerPage={this.handleChangeRowsPerPage}
+            />
           ) }
         </Paper>
 
@@ -47,13 +90,38 @@ class DeviceIndex extends Component {
 }
 
 function mapStateToProps(state) {
-  return {
-    devices: Object.values(state.entities.devices),
-  }
+  return {}
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchDevices, deleteDevice }, dispatch);
+  return bindActionCreators({ deleteDevice }, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DeviceIndex);
+const queryOptions = {
+  options: props => ({
+    variables: {
+      page: 1,
+      pageSize: 10
+    }
+  })
+}
+
+const query = gql`
+  query PaginatedDevicesQuery ($page: Int, $pageSize: Int) {
+    devices(page: $page, pageSize: $pageSize) {
+      entries {
+        name,
+        mac,
+        id
+      },
+      totalEntries,
+      totalPages,
+      pageSize,
+      pageNumber
+    }
+  }
+`
+
+const DeviceIndexWithData = graphql(query, queryOptions)(DeviceIndex)
+
+export default connect(mapStateToProps, mapDispatchToProps)(DeviceIndexWithData);

--- a/assets/js/components/devices/DevicesTable.jsx
+++ b/assets/js/components/devices/DevicesTable.jsx
@@ -5,13 +5,15 @@ import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
+import TableFooter from '@material-ui/core/TableFooter';
+import TablePagination from '@material-ui/core/TablePagination';
 import Button from '@material-ui/core/Button';
 import userCan from '../../util/abilities'
 
 class DevicesTable extends Component {
 
   render() {
-    const { devices, deleteDevice } = this.props
+    const { devices, deleteDevice, totalEntries, page, pageSize } = this.props
 
     return(
       <Table>
@@ -46,6 +48,17 @@ class DevicesTable extends Component {
             );
           })}
         </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TablePagination
+              count={totalEntries}
+              onChangePage={(e, page) => this.props.handleChangePage(page + 1)}
+              onChangeRowsPerPage={(e) => this.props.handleChangeRowsPerPage(e.target.value)}
+              page={page - 1}
+              rowsPerPage={pageSize}
+            />
+          </TableRow>
+        </TableFooter>
       </Table>
     )
   }

--- a/lib/console/devices/device_resolver.ex
+++ b/lib/console/devices/device_resolver.ex
@@ -1,8 +1,10 @@
 defmodule Console.Devices.DeviceResolver do
   alias Console.Repo
 
-  def all(_, %{context: %{current_team: current_team}}) do
-    devices = Ecto.assoc(current_team, :devices) |> Repo.all()
+  def paginate(%{page: page, page_size: page_size}, %{context: %{current_team: current_team}}) do
+    devices =
+      Ecto.assoc(current_team, :devices)
+      |> Repo.paginate(page: page, page_size: page_size)
     {:ok, devices}
   end
 

--- a/lib/console_web/schema/schema.ex
+++ b/lib/console_web/schema/schema.ex
@@ -3,6 +3,15 @@ defmodule ConsoleWeb.Schema do
   use ConsoleWeb.Schema.Paginated
   import_types Absinthe.Type.Custom
 
+  paginated object :device do
+    field :id, :id
+    field :name, :string
+    field :mac, :string
+    field :groups, list_of(:group) do
+      resolve &Console.Groups.GroupResolver.find/2
+    end
+  end
+
   # creates 2 obects: :paginated_event and :paginated_events
   paginated object :event do
     field :id, :id
@@ -31,15 +40,6 @@ defmodule ConsoleWeb.Schema do
     field :latitude, :decimal
   end
 
-  object :device do
-    field :id, :id
-    field :name, :string
-    field :mac, :string
-    field :groups, list_of(:group) do
-      resolve &Console.Groups.GroupResolver.find/2
-    end
-  end
-
   object :channel do
     field :id, :id
     field :name, :string
@@ -56,9 +56,9 @@ defmodule ConsoleWeb.Schema do
   end
 
   query do
-    @desc "Get all devices"
-    field :devices, list_of(:device) do
-      resolve(&Console.Devices.DeviceResolver.all/2)
+    @desc "Get paginated devices"
+    paginated field :devices, :paginated_devices do
+      resolve(&Console.Devices.DeviceResolver.paginate/2)
     end
 
     @desc "Get a single device"
@@ -86,7 +86,7 @@ defmodule ConsoleWeb.Schema do
       resolve &Console.Events.EventResolver.paginate/2
     end
 
-    @desc "Get all audit trails"
+    @desc "Get paginated audit trails"
     paginated field :audit_trails, :paginated_audit_trails do
       arg :user_id, :string
       resolve(&Console.Devices.AuditResolver.paginate/2)


### PR DESCRIPTION
Getting feedback before propogating to channels and gateways

If we are to keep the graphql data coming in at the DeviceIndex component level, we probably want to keep the page and pageSize in the state and pass it down to DeviceTable, which is a little ugly

