### PR TITLE
Add gql subscription to devices/channels/gateways

### DIFF
--- a/assets/js/components/audit_trails/AuditTable.jsx
+++ b/assets/js/components/audit_trails/AuditTable.jsx
@@ -14,8 +14,7 @@ import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import TableFooter from '@material-ui/core/TableFooter';
-import TablePagination from '@material-ui/core/TablePagination';
+import TableFooterPagination from '../common/TableFooterPagination'
 
 // Icons
 import DashboardIcon from '@material-ui/icons/Dashboard';
@@ -65,7 +64,7 @@ class AuditTable extends Component {
       )
     }
     const { auditTrails } = this.props.data
-    const { page } = this.state
+    const { page, pageSize } = this.state
 
     return (
       <CardContent>
@@ -93,17 +92,13 @@ class AuditTable extends Component {
               </TableRow>
             ))}
           </TableBody>
-          <TableFooter>
-            <TableRow>
-              <TablePagination
-                count={auditTrails.totalEntries}
-                onChangePage={(e, page) => this.handleChangePage(page + 1)}
-                onChangeRowsPerPage={(e) => this.handleChangeRowsPerPage(e.target.value)}
-                page={page - 1}
-                rowsPerPage={auditTrails.pageSize}
-              />
-            </TableRow>
-          </TableFooter>
+          <TableFooterPagination
+            totalEntries={auditTrails.totalEntries}
+            page={page}
+            pageSize={pageSize}
+            handleChangePage={this.handleChangePage}
+            handleChangeRowsPerPage={this.handleChangeRowsPerPage}
+          />
         </Table>
       </CardContent>
     )

--- a/assets/js/components/channels/ChannelIndex.jsx
+++ b/assets/js/components/channels/ChannelIndex.jsx
@@ -9,6 +9,7 @@ import DashboardLayout from '../common/DashboardLayout'
 import BlankSlate from '../common/BlankSlate'
 import userCan from '../../util/abilities'
 import ChannelCreateRow from './ChannelCreateRow'
+import { CHANNEL_SUBSCRIPTION, CHANNEL_FRAGMENT } from '../../graphql/channels'
 
 // GraphQL
 import { graphql } from 'react-apollo';
@@ -38,7 +39,7 @@ class ChannelIndex extends Component {
     const { subscribeToMore } = this.props.data
 
     subscribeToMore({
-      document: CHANNELS_SUBSCRIPTION,
+      document: CHANNEL_SUBSCRIPTION,
       variables: {teamId: this.props.currentTeamId},
       updateQuery: (prev, { subscriptionData }) => {
         if (!subscriptionData.data) return prev
@@ -62,7 +63,7 @@ class ChannelIndex extends Component {
 
   handleSubscriptionChannelAdded() {
     const { page, pageSize } = this.state
-    
+
     this.refetchPaginatedChannels(page, pageSize)
   }
 
@@ -144,9 +145,7 @@ const query = gql`
   query PaginatedChannelsQuery ($page: Int, $pageSize: Int) {
     channels(page: $page, pageSize: $pageSize) {
       entries {
-        name,
-        type,
-        id
+        ...ChannelFragment
       },
       totalEntries,
       totalPages,
@@ -154,16 +153,7 @@ const query = gql`
       pageNumber
     }
   }
-`
-
-const CHANNELS_SUBSCRIPTION = gql`
-  subscription onChannelAdded($teamId: String) {
-    channelAdded(teamId: $teamId) {
-      name,
-      type,
-      id
-    }
-  }
+  ${CHANNEL_FRAGMENT}
 `
 
 const ChannelIndexWithData = graphql(query, queryOptions)(ChannelIndex)

--- a/assets/js/components/channels/ChannelIndex.jsx
+++ b/assets/js/components/channels/ChannelIndex.jsx
@@ -40,7 +40,6 @@ class ChannelIndex extends Component {
 
     subscribeToMore({
       document: CHANNEL_SUBSCRIPTION,
-      variables: {teamId: this.props.currentTeamId},
       updateQuery: (prev, { subscriptionData }) => {
         if (!subscriptionData.data) return prev
         this.handleSubscriptionChannelAdded()
@@ -123,9 +122,7 @@ class ChannelIndex extends Component {
 }
 
 function mapStateToProps(state) {
-  return {
-    currentTeamId: state.auth.currentTeamId
-  }
+  return {}
 }
 
 function mapDispatchToProps(dispatch) {

--- a/assets/js/components/channels/ChannelIndex.jsx
+++ b/assets/js/components/channels/ChannelIndex.jsx
@@ -133,12 +133,16 @@ function mapDispatchToProps(dispatch) {
 }
 
 const queryOptions = {
-  options: props => ({
-    variables: {
+  options: props => {
+    const variables = {
       page: 1,
-      pageSize: 10
+      pageSize: 10,
     }
-  })
+    return {
+      fetchPolicy: 'network-only',
+      variables
+    }
+  }
 }
 
 const query = gql`

--- a/assets/js/components/channels/ChannelShow.jsx
+++ b/assets/js/components/channels/ChannelShow.jsx
@@ -11,6 +11,7 @@ import HttpDetails from './HttpDetails'
 import GroupsControl from '../common/GroupsControl'
 import PacketGraph from '../common/PacketGraph'
 import userCan from '../../util/abilities'
+import { CHANNEL_FRAGMENT } from '../../graphql/channels'
 
 // GraphQL
 import { graphql } from 'react-apollo';
@@ -139,16 +140,13 @@ const queryOptions = {
 const query = gql`
   query ChannelShowQuery ($id: ID!) {
     channel(id: $id) {
-      name,
-      type,
-      type_name,
-      active,
-      id,
+      ...ChannelFragment
       groups {
         name
       }
     }
   }
+  ${CHANNEL_FRAGMENT}
 `
 
 const ChannelShowWithData = graphql(query, queryOptions)(ChannelShow)

--- a/assets/js/components/channels/ChannelsTable.jsx
+++ b/assets/js/components/channels/ChannelsTable.jsx
@@ -5,10 +5,9 @@ import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import TableFooter from '@material-ui/core/TableFooter';
-import TablePagination from '@material-ui/core/TablePagination';
+import TableFooterPagination from '../common/TableFooterPagination'
 import Button from '@material-ui/core/Button';
-import userCan from '../../util/abilities'
+import userCan from '../../util/abilities';
 
 class ChannelsTable extends Component {
 
@@ -48,17 +47,13 @@ class ChannelsTable extends Component {
             );
           })}
         </TableBody>
-        <TableFooter>
-          <TableRow>
-            <TablePagination
-              count={totalEntries}
-              onChangePage={(e, page) => this.props.handleChangePage(page + 1)}
-              onChangeRowsPerPage={(e) => this.props.handleChangeRowsPerPage(e.target.value)}
-              page={page - 1}
-              rowsPerPage={pageSize}
-            />
-          </TableRow>
-        </TableFooter>
+        <TableFooterPagination
+          totalEntries={totalEntries}
+          page={page}
+          pageSize={pageSize}
+          handleChangePage={this.props.handleChangePage}
+          handleChangeRowsPerPage={this.props.handleChangeRowsPerPage}
+        />
       </Table>
     )
   }

--- a/assets/js/components/common/TableFooterPagination.jsx
+++ b/assets/js/components/common/TableFooterPagination.jsx
@@ -1,0 +1,26 @@
+import React, { Component } from 'react'
+import TableRow from '@material-ui/core/TableRow';
+import TableFooter from '@material-ui/core/TableFooter';
+import TablePagination from '@material-ui/core/TablePagination';
+
+class TableFooterPagination extends Component {
+  render() {
+    const { totalEntries, page, pageSize, handleChangePage, handleChangeRowsPerPage } = this.props
+
+    return(
+      <TableFooter>
+        <TableRow>
+          <TablePagination
+            count={totalEntries}
+            onChangePage={(e, page) => handleChangePage(page + 1)}
+            onChangeRowsPerPage={(e) => handleChangeRowsPerPage(e.target.value)}
+            page={page - 1}
+            rowsPerPage={pageSize}
+          />
+        </TableRow>
+      </TableFooter>
+    )
+  }
+}
+
+export default TableFooterPagination

--- a/assets/js/components/devices/DeviceIndex.jsx
+++ b/assets/js/components/devices/DeviceIndex.jsx
@@ -8,6 +8,7 @@ import DevicesTable from './DevicesTable'
 import DashboardLayout from '../common/DashboardLayout'
 import BlankSlate from '../common/BlankSlate'
 import userCan from '../../util/abilities'
+import { DEVICE_SUBSCRIPTION, DEVICE_FRAGMENT } from '../../graphql/devices'
 
 // GraphQL
 import { graphql } from 'react-apollo';
@@ -36,7 +37,7 @@ class DeviceIndex extends Component {
     const { subscribeToMore } = this.props.data
 
     subscribeToMore({
-      document: DEVICES_SUBSCRIPTION,
+      document: DEVICE_SUBSCRIPTION,
       variables: {teamId: this.props.currentTeamId},
       updateQuery: (prev, { subscriptionData }) => {
         if (!subscriptionData.data) return prev
@@ -47,7 +48,7 @@ class DeviceIndex extends Component {
 
   handleChangeRowsPerPage(pageSize) {
     this.setState({ pageSize, page: 1 })
-    
+
     this.refetchPaginatedDevices(1, pageSize)
   }
 
@@ -131,9 +132,7 @@ const query = gql`
   query PaginatedDevicesQuery ($page: Int, $pageSize: Int) {
     devices(page: $page, pageSize: $pageSize) {
       entries {
-        name,
-        mac,
-        id
+        ...DeviceFragment
       },
       totalEntries,
       totalPages,
@@ -141,16 +140,7 @@ const query = gql`
       pageNumber
     }
   }
-`
-
-const DEVICES_SUBSCRIPTION = gql`
-  subscription onDeviceAdded($teamId: String) {
-    deviceAdded(teamId: $teamId) {
-      name,
-      mac,
-      id
-    }
-  }
+  ${DEVICE_FRAGMENT}
 `
 
 const DeviceIndexWithData = graphql(query, queryOptions)(DeviceIndex)

--- a/assets/js/components/devices/DeviceIndex.jsx
+++ b/assets/js/components/devices/DeviceIndex.jsx
@@ -29,23 +29,42 @@ class DeviceIndex extends Component {
 
     this.handleChangePage = this.handleChangePage.bind(this)
     this.handleChangeRowsPerPage = this.handleChangeRowsPerPage.bind(this)
+    this.handleSubscriptionDeviceAdded = this.handleSubscriptionDeviceAdded.bind(this)
+  }
+
+  componentDidMount() {
+    const { subscribeToMore } = this.props.data
+
+    subscribeToMore({
+      document: DEVICES_SUBSCRIPTION,
+      variables: {teamId: this.props.currentTeamId},
+      updateQuery: (prev, { subscriptionData }) => {
+        if (!subscriptionData.data) return prev
+        this.handleSubscriptionDeviceAdded()
+      }
+    })
   }
 
   handleChangeRowsPerPage(pageSize) {
     this.setState({ pageSize, page: 1 })
-    const { fetchMore } = this.props.data
-
-    fetchMore({
-      variables: { page: 1, pageSize },
-      updateQuery: (prev, { fetchMoreResult }) => fetchMoreResult
-    })
+    
+    this.refetchPaginatedDevices(1, pageSize)
   }
 
   handleChangePage(page) {
     this.setState({ page })
-    const { fetchMore } = this.props.data
-    const { pageSize } = this.state
 
+    const { pageSize } = this.state
+    this.refetchPaginatedDevices(page, pageSize)
+  }
+
+  handleSubscriptionDeviceAdded() {
+    const { page, pageSize } = this.state
+    this.refetchPaginatedDevices(page, pageSize)
+  }
+
+  refetchPaginatedDevices(page, pageSize) {
+    const { fetchMore } = this.props.data
     fetchMore({
       variables: { page, pageSize },
       updateQuery: (prev, { fetchMoreResult }) => fetchMoreResult
@@ -90,7 +109,9 @@ class DeviceIndex extends Component {
 }
 
 function mapStateToProps(state) {
-  return {}
+  return {
+    currentTeamId: state.auth.currentTeamId
+  }
 }
 
 function mapDispatchToProps(dispatch) {
@@ -118,6 +139,16 @@ const query = gql`
       totalPages,
       pageSize,
       pageNumber
+    }
+  }
+`
+
+const DEVICES_SUBSCRIPTION = gql`
+  subscription onDeviceAdded($teamId: String) {
+    deviceAdded(teamId: $teamId) {
+      name,
+      mac,
+      id
     }
   }
 `

--- a/assets/js/components/devices/DeviceIndex.jsx
+++ b/assets/js/components/devices/DeviceIndex.jsx
@@ -38,7 +38,6 @@ class DeviceIndex extends Component {
 
     subscribeToMore({
       document: DEVICE_SUBSCRIPTION,
-      variables: {teamId: this.props.currentTeamId},
       updateQuery: (prev, { subscriptionData }) => {
         if (!subscriptionData.data) return prev
         this.handleSubscriptionDeviceAdded()
@@ -110,9 +109,7 @@ class DeviceIndex extends Component {
 }
 
 function mapStateToProps(state) {
-  return {
-    currentTeamId: state.auth.currentTeamId
-  }
+  return {}
 }
 
 function mapDispatchToProps(dispatch) {

--- a/assets/js/components/devices/DeviceShow.jsx
+++ b/assets/js/components/devices/DeviceShow.jsx
@@ -10,6 +10,7 @@ import DashboardLayout from '../common/DashboardLayout'
 import GroupsControl from '../common/GroupsControl'
 import PacketGraph from '../common/PacketGraph'
 import userCan from '../../util/abilities'
+import { DEVICE_FRAGMENT } from '../../graphql/devices'
 
 // GraphQL
 import { graphql } from 'react-apollo';
@@ -132,14 +133,13 @@ const queryOptions = {
 const query = gql`
   query DeviceShowQuery ($id: ID!) {
     device(id: $id) {
-      name,
-      mac,
-      id,
+      ...DeviceFragment
       groups {
         name
       }
     }
   }
+  ${DEVICE_FRAGMENT}
 `
 
 const DeviceShowWithData = graphql(query, queryOptions)(DeviceShow)

--- a/assets/js/components/devices/DevicesTable.jsx
+++ b/assets/js/components/devices/DevicesTable.jsx
@@ -5,8 +5,7 @@ import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import TableFooter from '@material-ui/core/TableFooter';
-import TablePagination from '@material-ui/core/TablePagination';
+import TableFooterPagination from '../common/TableFooterPagination'
 import Button from '@material-ui/core/Button';
 import userCan from '../../util/abilities'
 
@@ -48,17 +47,13 @@ class DevicesTable extends Component {
             );
           })}
         </TableBody>
-        <TableFooter>
-          <TableRow>
-            <TablePagination
-              count={totalEntries}
-              onChangePage={(e, page) => this.props.handleChangePage(page + 1)}
-              onChangeRowsPerPage={(e) => this.props.handleChangeRowsPerPage(e.target.value)}
-              page={page - 1}
-              rowsPerPage={pageSize}
-            />
-          </TableRow>
-        </TableFooter>
+        <TableFooterPagination
+          totalEntries={totalEntries}
+          page={page}
+          pageSize={pageSize}
+          handleChangePage={this.props.handleChangePage}
+          handleChangeRowsPerPage={this.props.handleChangeRowsPerPage}
+        />
       </Table>
     )
   }

--- a/assets/js/components/events/EventsTablePaginated.jsx
+++ b/assets/js/components/events/EventsTablePaginated.jsx
@@ -12,8 +12,7 @@ import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import TableFooter from '@material-ui/core/TableFooter';
-import TablePagination from '@material-ui/core/TablePagination';
+import TableFooterPagination from '../common/TableFooterPagination'
 
 const EventStatus = (props) => {
   switch(props.status) {
@@ -97,7 +96,7 @@ class EventsTablePaginated extends Component {
 
   render() {
     const { loading, events } = this.props.data
-    const { page } = this.state
+    const { page, pageSize } = this.state
 
     if (loading) return <div />
 
@@ -133,17 +132,13 @@ class EventsTablePaginated extends Component {
             </TableRow>
           ))}
         </TableBody>
-        <TableFooter>
-          <TableRow>
-            <TablePagination
-              count={events.totalEntries}
-              onChangePage={(e, page) => this.handleChangePage(page + 1)}
-              onChangeRowsPerPage={(e) => this.handleChangeRowsPerPage(e.target.value)}
-              page={page - 1}
-              rowsPerPage={events.pageSize}
-            />
-          </TableRow>
-        </TableFooter>
+        <TableFooterPagination
+          totalEntries={events.totalEntries}
+          page={page}
+          pageSize={pageSize}
+          handleChangePage={this.handleChangePage}
+          handleChangeRowsPerPage={this.handleChangeRowsPerPage}
+        />
       </Table>
     )
   }

--- a/assets/js/components/gateways/GatewayIndex.jsx
+++ b/assets/js/components/gateways/GatewayIndex.jsx
@@ -41,7 +41,6 @@ class GatewayIndex extends Component {
 
     subscribeToMore({
       document: GATEWAY_SUBSCRIPTION,
-      variables: {teamId: this.props.currentTeamId},
       updateQuery: (prev, { subscriptionData }) => {
         if (!subscriptionData.data) return prev
         this.handleSubscriptionGatewayAdded()
@@ -138,9 +137,7 @@ class GatewayIndex extends Component {
 }
 
 function mapStateToProps(state) {
-  return {
-    currentTeamId: state.auth.currentTeamId
-  }
+  return {}
 }
 
 function mapDispatchToProps(dispatch) {

--- a/assets/js/components/gateways/GatewayIndex.jsx
+++ b/assets/js/components/gateways/GatewayIndex.jsx
@@ -9,6 +9,7 @@ import DashboardLayout from '../common/DashboardLayout'
 import BlankSlate from '../common/BlankSlate'
 import Mapbox from '../common/Mapbox'
 import userCan from '../../util/abilities'
+import { GATEWAY_SUBSCRIPTION, GATEWAY_FRAGMENT } from '../../graphql/gateways'
 
 // GraphQL
 import { graphql } from 'react-apollo';
@@ -39,7 +40,7 @@ class GatewayIndex extends Component {
     const { subscribeToMore } = this.props.data
 
     subscribeToMore({
-      document: GATEWAYS_SUBSCRIPTION,
+      document: GATEWAY_SUBSCRIPTION,
       variables: {teamId: this.props.currentTeamId},
       updateQuery: (prev, { subscriptionData }) => {
         if (!subscriptionData.data) return prev
@@ -159,11 +160,7 @@ const query = gql`
   query PaginatedGatewaysQuery ($page: Int, $pageSize: Int) {
     gateways(page: $page, pageSize: $pageSize) {
       entries {
-        name,
-        mac,
-        id,
-        latitude,
-        longitude
+        ...GatewayFragment
       },
       totalEntries,
       totalPages,
@@ -171,18 +168,7 @@ const query = gql`
       pageNumber
     }
   }
-`
-
-const GATEWAYS_SUBSCRIPTION = gql`
-  subscription onGatewayAdded($teamId: String) {
-    gatewayAdded(teamId: $teamId) {
-      name,
-      mac,
-      id,
-      latitude,
-      longitude
-    }
-  }
+  ${GATEWAY_FRAGMENT}
 `
 
 const GatewayIndexWithData = graphql(query, queryOptions)(GatewayIndex)

--- a/assets/js/components/gateways/GatewayShow.jsx
+++ b/assets/js/components/gateways/GatewayShow.jsx
@@ -10,6 +10,7 @@ import DashboardLayout from '../common/DashboardLayout'
 import Mapbox from '../common/Mapbox'
 import PacketGraph from '../common/PacketGraph'
 import userCan from '../../util/abilities'
+import { GATEWAY_FRAGMENT } from '../../graphql/gateways'
 
 // GraphQL
 import { graphql } from 'react-apollo';
@@ -131,13 +132,10 @@ const queryOptions = {
 const query = gql`
   query GatewayShowQuery ($id: ID!) {
     gateway(id: $id) {
-      name,
-      mac,
-      id,
-      latitude,
-      longitude
+      ...GatewayFragment
     }
   }
+  ${GATEWAY_FRAGMENT}
 `
 const GatewayShowWithData = graphql(query, queryOptions)(GatewayShow)
 

--- a/assets/js/components/gateways/GatewaysTable.jsx
+++ b/assets/js/components/gateways/GatewaysTable.jsx
@@ -5,8 +5,7 @@ import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import TableFooter from '@material-ui/core/TableFooter';
-import TablePagination from '@material-ui/core/TablePagination';
+import TableFooterPagination from '../common/TableFooterPagination'
 import Button from '@material-ui/core/Button';
 import userCan from '../../util/abilities'
 
@@ -48,17 +47,13 @@ class GatewaysTable extends Component {
             );
           })}
         </TableBody>
-        <TableFooter>
-          <TableRow>
-            <TablePagination
-              count={totalEntries}
-              onChangePage={(e, page) => this.props.handleChangePage(page + 1)}
-              onChangeRowsPerPage={(e) => this.props.handleChangeRowsPerPage(e.target.value)}
-              page={page - 1}
-              rowsPerPage={pageSize}
-            />
-          </TableRow>
-        </TableFooter>
+        <TableFooterPagination
+          totalEntries={totalEntries}
+          page={page}
+          pageSize={pageSize}
+          handleChangePage={this.props.handleChangePage}
+          handleChangeRowsPerPage={this.props.handleChangeRowsPerPage}
+        />
       </Table>
     )
   }

--- a/assets/js/graphql/channels.js
+++ b/assets/js/graphql/channels.js
@@ -1,0 +1,20 @@
+import gql from 'graphql-tag';
+
+export const CHANNEL_FRAGMENT = gql`
+  fragment ChannelFragment on Channel {
+    name,
+    type,
+    type_name,
+    id,
+    active
+  }
+`
+
+export const CHANNEL_SUBSCRIPTION = gql`
+  subscription onChannelAdded($teamId: String) {
+    channelAdded(teamId: $teamId) {
+      ...ChannelFragment
+    }
+  }
+  ${CHANNEL_FRAGMENT}
+`

--- a/assets/js/graphql/channels.js
+++ b/assets/js/graphql/channels.js
@@ -11,8 +11,8 @@ export const CHANNEL_FRAGMENT = gql`
 `
 
 export const CHANNEL_SUBSCRIPTION = gql`
-  subscription onChannelAdded($teamId: String) {
-    channelAdded(teamId: $teamId) {
+  subscription onChannelAdded {
+    channelAdded {
       ...ChannelFragment
     }
   }

--- a/assets/js/graphql/devices.js
+++ b/assets/js/graphql/devices.js
@@ -1,0 +1,18 @@
+import gql from 'graphql-tag';
+
+export const DEVICE_FRAGMENT = gql`
+  fragment DeviceFragment on Device {
+    name,
+    mac,
+    id
+  }
+`
+
+export const DEVICE_SUBSCRIPTION = gql`
+  subscription onDeviceAdded($teamId: String) {
+    deviceAdded(teamId: $teamId) {
+      ...DeviceFragment
+    }
+  }
+  ${DEVICE_FRAGMENT}
+`

--- a/assets/js/graphql/devices.js
+++ b/assets/js/graphql/devices.js
@@ -9,8 +9,8 @@ export const DEVICE_FRAGMENT = gql`
 `
 
 export const DEVICE_SUBSCRIPTION = gql`
-  subscription onDeviceAdded($teamId: String) {
-    deviceAdded(teamId: $teamId) {
+  subscription onDeviceAdded {
+    deviceAdded {
       ...DeviceFragment
     }
   }

--- a/assets/js/graphql/gateways.js
+++ b/assets/js/graphql/gateways.js
@@ -11,8 +11,8 @@ export const GATEWAY_FRAGMENT = gql`
 `
 
 export const GATEWAY_SUBSCRIPTION = gql`
-  subscription onGatewayAdded($teamId: String) {
-    gatewayAdded(teamId: $teamId) {
+  subscription onGatewayAdded {
+    gatewayAdded {
       ...GatewayFragment
     }
   }

--- a/assets/js/graphql/gateways.js
+++ b/assets/js/graphql/gateways.js
@@ -1,0 +1,20 @@
+import gql from 'graphql-tag';
+
+export const GATEWAY_FRAGMENT = gql`
+  fragment GatewayFragment on Gateway {
+    name,
+    mac,
+    id,
+    latitude,
+    longitude
+  }
+`
+
+export const GATEWAY_SUBSCRIPTION = gql`
+  subscription onGatewayAdded($teamId: String) {
+    gatewayAdded(teamId: $teamId) {
+      ...GatewayFragment
+    }
+  }
+  ${GATEWAY_FRAGMENT}
+`

--- a/lib/console_web/channels/user_socket.ex
+++ b/lib/console_web/channels/user_socket.ex
@@ -30,6 +30,9 @@ defmodule ConsoleWeb.UserSocket do
   def connect(%{"token" => token}, socket) do
     case Guardian.Phoenix.Socket.authenticate(socket, ConsoleWeb.Guardian, token) do
       {:ok, authed_socket} ->
+        authed_socket = Absinthe.Phoenix.Socket.put_opts(authed_socket, context: %{
+          current_team_id: authed_socket.assigns.guardian_default_claims["team"]
+        })
         {:ok, authed_socket}
 
       {:error, _} ->

--- a/lib/console_web/controllers/channel_controller.ex
+++ b/lib/console_web/controllers/channel_controller.ex
@@ -71,5 +71,7 @@ defmodule ConsoleWeb.ChannelController do
     channel = Channels.fetch_assoc(channel, [:team])
     body = ConsoleWeb.ChannelView.render("show.json", channel: channel)
     ConsoleWeb.Endpoint.broadcast("channel:#{channel.team.id}", action, body)
+
+    Absinthe.Subscription.publish(ConsoleWeb.Endpoint, channel, channel_added: "#{channel.team.id}/channel_added")
   end
 end

--- a/lib/console_web/controllers/device_controller.ex
+++ b/lib/console_web/controllers/device_controller.ex
@@ -72,5 +72,7 @@ defmodule ConsoleWeb.DeviceController do
     device = Devices.fetch_assoc(device, [:team])
     body = ConsoleWeb.DeviceView.render("show.json", device: device)
     ConsoleWeb.Endpoint.broadcast("device:#{device.team.id}", action, body)
+
+    Absinthe.Subscription.publish(ConsoleWeb.Endpoint, device, device_added: "#{device.team.id}/device_added")
   end
 end

--- a/lib/console_web/controllers/gateway_controller.ex
+++ b/lib/console_web/controllers/gateway_controller.ex
@@ -63,5 +63,7 @@ defmodule ConsoleWeb.GatewayController do
     gateway = Gateways.fetch_assoc(gateway, [:team])
     body = ConsoleWeb.GatewayView.render("show.json", gateway: gateway)
     ConsoleWeb.Endpoint.broadcast("gateway:#{gateway.team.id}", action, body)
+
+    Absinthe.Subscription.publish(ConsoleWeb.Endpoint, gateway, gateway_added: "#{gateway.team.id}/gateway_added")
   end
 end

--- a/lib/console_web/schema/schema.ex
+++ b/lib/console_web/schema/schema.ex
@@ -135,5 +135,29 @@ defmodule ConsoleWeb.Schema do
         {:ok, topic: "#{args.context_name}/#{args.context_id}"}
       end
     end
+
+    field :device_added, :device do
+      arg :team_id, :string
+
+      config fn args, _ ->
+        {:ok, topic: "#{args.team_id}/device_added"}
+      end
+    end
+
+    field :gateway_added, :gateway do
+      arg :team_id, :string
+
+      config fn args, _ ->
+        {:ok, topic: "#{args.team_id}/gateway_added"}
+      end
+    end
+
+    field :channel_added, :channel do
+      arg :team_id, :string
+
+      config fn args, _ ->
+        {:ok, topic: "#{args.team_id}/channel_added"}
+      end
+    end
   end
 end

--- a/lib/console_web/schema/schema.ex
+++ b/lib/console_web/schema/schema.ex
@@ -137,26 +137,20 @@ defmodule ConsoleWeb.Schema do
     end
 
     field :device_added, :device do
-      arg :team_id, :string
-
-      config fn args, _ ->
-        {:ok, topic: "#{args.team_id}/device_added"}
+      config fn _, %{context: %{ current_team_id: team_id }} ->
+        {:ok, topic: "#{team_id}/device_added"}
       end
     end
 
     field :gateway_added, :gateway do
-      arg :team_id, :string
-
-      config fn args, _ ->
-        {:ok, topic: "#{args.team_id}/gateway_added"}
+      config fn _, %{context: %{ current_team_id: team_id }} ->
+        {:ok, topic: "#{team_id}/gateway_added"}
       end
     end
 
     field :channel_added, :channel do
-      arg :team_id, :string
-
-      config fn args, _ ->
-        {:ok, topic: "#{args.team_id}/channel_added"}
+      config fn _, %{context: %{ current_team_id: team_id }} ->
+        {:ok, topic: "#{team_id}/channel_added"}
       end
     end
   end


### PR DESCRIPTION
+ Refactor table footer pagination
+ Create fragments for device/channel/gateway


should device/channel/gateway index graphql queries not be cached? Currently, creating a new channel using the button and clicking back to the channelIndex page causes the new channel to not show up until we refresh the page