### PR TITLE
Add geocoding to gateway create

### DIFF
--- a/assets/js/components/common/BlankSlate.jsx
+++ b/assets/js/components/common/BlankSlate.jsx
@@ -29,10 +29,6 @@ const styles = theme => ({
 
 @withStyles(styles)
 class BlankSlate extends Component {
-  constructor(props) {
-    super(props)
-  }
-  
   render() {
     const { classes, title, subheading } = this.props
 

--- a/assets/js/components/common/BlankSlate.jsx
+++ b/assets/js/components/common/BlankSlate.jsx
@@ -29,18 +29,22 @@ const styles = theme => ({
 
 @withStyles(styles)
 class BlankSlate extends Component {
+  constructor(props) {
+    super(props)
+  }
+  
   render() {
-    const { classes } = props
+    const { classes, title, subheading } = this.props
 
     return (
       <div className={classes.main}>
         <Icon className={classes.icon} />
         <Typography variant="display1" className={classes.title}>
-          {props.title}
+          {title}
         </Typography>
 
         <Typography component="p" className={classes.subheading}>
-          {props.subheading}
+          {subheading}
         </Typography>
       </div>
     )

--- a/assets/js/components/common/Mapbox.jsx
+++ b/assets/js/components/common/Mapbox.jsx
@@ -67,7 +67,7 @@ class Mapbox extends Component {
       features.push({
         "type": "Feature",
         "properties": {
-          "description": `<div><p class="blue">${gateway.name}</p><p>${gateway.longitude}, ${gateway.latitude}</p></div>`,
+          "description": `<div><p class="blue">${gateway.name}</p><p>${this.parseLocation(gateway.location)}</p></div>`,
           "id": gateway.id
         },
         "geometry": {
@@ -165,9 +165,17 @@ class Mapbox extends Component {
     }
   }
 
+  parseLocation(location) {
+    if (location == "unknown_location" || location == "api_call_failed") {
+      return "Location Unavailable"
+    } else {
+      return location
+    }
+  }
+
   render() {
     let style
-    if (this.props.gateways.length == 1) {
+    if (this.props.view == "show") {
       style = {
         width: '100%',
         height: '280px'

--- a/assets/js/graphql/gateways.js
+++ b/assets/js/graphql/gateways.js
@@ -5,6 +5,7 @@ export const GATEWAY_FRAGMENT = gql`
     name,
     mac,
     id,
+    location,
     latitude,
     longitude
   }

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -73,3 +73,4 @@ config :console, Console.Mailer,
   adapter: Bamboo.LocalAdapter
 
 config :console, recaptcha_secret: "6Lew200UAAAAAA-Z2uxdyuC2RrdCjCpuncsXzCh3"
+config :console, google_maps_secret: "AIzaSyBDifcwr-8OoEj024h_rN6IvXOWIyGXwEE"

--- a/lib/console/gateways/gateway.ex
+++ b/lib/console/gateways/gateway.ex
@@ -12,6 +12,7 @@ defmodule Console.Gateways.Gateway do
     field :longitude, :decimal
     field :mac, :string
     field :name, :string
+    field :location, :string
     field :public_key, :binary
 
     belongs_to :team, Team
@@ -23,7 +24,7 @@ defmodule Console.Gateways.Gateway do
   @doc false
   def changeset(gateway, attrs) do
     gateway
-    |> cast(attrs, [:name, :mac, :public_key, :latitude, :longitude, :team_id])
+    |> cast(attrs, [:name, :mac, :public_key, :latitude, :longitude, :team_id, :location])
     |> validate_required([:name, :mac, :public_key, :latitude, :longitude, :team_id])
     |> unique_constraint(:mac)
   end

--- a/lib/console/gateways/gateway.ex
+++ b/lib/console/gateways/gateway.ex
@@ -33,8 +33,8 @@ defmodule Console.Gateways.Gateway do
 
   defp putGeocodingLocation(changeset) do
     case changeset do
-      %Ecto.Changeset{valid?: true, changes: changes} ->
-        put_change(changeset, :location, Helpers.geocodeLatLng(changes.latitude, changes.longitude))
+      %Ecto.Changeset{valid?: true, changes: %{ latitude: lat, longitude: lng}} ->
+        put_change(changeset, :location, Helpers.geocodeLatLng(lat, lng))
       _ -> changeset
     end
   end

--- a/lib/console/gateways/gateway.ex
+++ b/lib/console/gateways/gateway.ex
@@ -4,6 +4,7 @@ defmodule Console.Gateways.Gateway do
 
   alias Console.Teams.Team
   alias Console.Events.Event
+  alias Console.Helpers
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -24,8 +25,17 @@ defmodule Console.Gateways.Gateway do
   @doc false
   def changeset(gateway, attrs) do
     gateway
-    |> cast(attrs, [:name, :mac, :public_key, :latitude, :longitude, :team_id, :location])
+    |> cast(attrs, [:name, :mac, :public_key, :latitude, :longitude, :team_id])
     |> validate_required([:name, :mac, :public_key, :latitude, :longitude, :team_id])
+    |> putGeocodingLocation()
     |> unique_constraint(:mac)
+  end
+
+  defp putGeocodingLocation(changeset) do
+    case changeset do
+      %Ecto.Changeset{valid?: true, changes: changes} ->
+        put_change(changeset, :location, Helpers.geocodeLatLng(changes.latitude, changes.longitude))
+      _ -> changeset
+    end
   end
 end

--- a/lib/console_web/controllers/gateway_controller.ex
+++ b/lib/console_web/controllers/gateway_controller.ex
@@ -18,7 +18,9 @@ defmodule ConsoleWeb.GatewayController do
   def create(conn, %{"gateway" => gateway_params}) do
     current_user = conn.assigns.current_user
     current_team = conn.assigns.current_team
-    gateway_params = Map.merge(gateway_params, %{"team_id" => current_team.id})
+    location = geocodeLatLng(gateway_params)
+
+    gateway_params = Map.merge(gateway_params, %{"team_id" => current_team.id, "location" => location})
     with {:ok, %Gateway{} = gateway} <- Gateways.create_gateway(gateway_params) do
       broadcast(gateway, "new")
       AuditTrails.create_audit_trail("gateway", "create", current_user, current_team, "gateways", gateway)
@@ -65,5 +67,26 @@ defmodule ConsoleWeb.GatewayController do
     ConsoleWeb.Endpoint.broadcast("gateway:#{gateway.team.id}", action, body)
 
     Absinthe.Subscription.publish(ConsoleWeb.Endpoint, gateway, gateway_added: "#{gateway.team.id}/gateway_added")
+  end
+
+  defp geocodeLatLng(%{"latitude" => lat, "longitude" => lng}) do
+    case HTTPoison.get("https://maps.googleapis.com/maps/api/geocode/json?latlng=#{lat},#{lng}&key=#{Application.get_env(:console, :google_maps_secret)}") do
+      {:ok, response} ->
+        case response.status_code do
+          200 ->
+            responseBody = Poison.decode!(response.body)
+
+            case List.first(responseBody["results"]) do
+              %{"address_components" => address_components} ->
+                city = Enum.find(address_components, fn c -> c["types"] == ["locality", "political"] end)["long_name"] || "Unknown"
+                state = Enum.find(address_components, fn c -> c["types"] == ["administrative_area_level_1", "political"] end)["long_name"] || "Unknown"
+                country = Enum.find(address_components, fn c -> c["types"] == ["country", "political"] end)["short_name"] || "Unknown"
+                "#{city}, #{state}, #{country}"
+              _ -> "unknown_location"
+            end
+          _ -> "api_call_failed"
+        end
+      _ -> "api_call_failed"
+    end
   end
 end

--- a/lib/console_web/schema/schema.ex
+++ b/lib/console_web/schema/schema.ex
@@ -27,6 +27,7 @@ defmodule ConsoleWeb.Schema do
     field :id, :id
     field :name, :string
     field :mac, :string
+    field :location, :string
     field :longitude, :decimal
     field :latitude, :decimal
   end

--- a/priv/repo/migrations/20180606173330_add_location_field_to_gateways.exs
+++ b/priv/repo/migrations/20180606173330_add_location_field_to_gateways.exs
@@ -1,0 +1,11 @@
+defmodule Console.Repo.Migrations.AddLocationFieldToGateways do
+  use Ecto.Migration
+
+  def change do
+    alter table(:gateways) do
+      add :location, :string
+    end
+
+    create index(:gateways, [:location])
+  end
+end


### PR DESCRIPTION
Yet to do:
1. Update gateway location by re-geocoding if geocoding during gateway creation fails, IE location field == api_call_failed