### PR TITLE
Fix bugs when user unavailable on server

### DIFF
--- a/assets/js/actions/user.js
+++ b/assets/js/actions/user.js
@@ -1,4 +1,5 @@
 import * as rest from '../util/rest';
+import { replace } from 'react-router-redux';
 
 export const RECEIVE_USER = 'RECEIVE_USER';
 
@@ -7,6 +8,10 @@ export const fetchUser = () => {
     rest.get('/api/users/current')
       .then(response => {
         dispatch(receiveUser(response.data))
+      })
+      .catch(err => {
+        localStorage.clear()
+        dispatch(replace('/'))
       })
   };
 }

--- a/assets/js/components/common/PacketGraph.jsx
+++ b/assets/js/components/common/PacketGraph.jsx
@@ -108,7 +108,7 @@ class PacketGraph extends Component {
   componentDidUpdate(prevProps) {
     const { recentEvents } = this.props.data
 
-    if ((!prevProps.data.recentEvents && recentEvents) || (prevProps.data.recentEvents.length !== recentEvents.length)) {
+    if ((!prevProps.data.demoEvents && demoEvents) || (prevProps.data.demoEvents && demoEvents) && (prevProps.data.demoEvents.length !== demoEvents.length)) {
       clearInterval(this.chartUpdateInterval)
       this.updateChart(recentEvents)
       this.chartUpdateInterval = setInterval(() => {


### PR DESCRIPTION
- Packet graph won't prevent page from loading if graphql query 500s
- if user in localstorage token does not exist on server, clear localstorage