### PR TITLE
Updates to allow users to hit the organizations index without a prev org

### DIFF
--- a/assets/js/Router.jsx
+++ b/assets/js/Router.jsx
@@ -47,6 +47,7 @@ const Router = (props) => {
       }
     }
     const fn = async () => {
+      localStorage.removeItem('organization');
       await loginWithRedirect({
         appState: {targetUrl: window.location.pathname, params: window.location.search}
       });

--- a/lib/console_web/router.ex
+++ b/lib/console_web/router.ex
@@ -15,22 +15,10 @@ defmodule ConsoleWeb.Router do
     plug ConsoleWeb.Plug.RateLimit, ["auth_actions", 60]
   end
 
-  pipeline :no_organization do
-    plug ConsoleWeb.Plug.RateLimit, ["organization_idx", 300]
-    plug ConsoleWeb.Plug.VerifyAccessToken
-    plug ConsoleWeb.Plug.PutCurrentUser
-  end
-
   scope "/graphql" do
     pipe_through ConsoleWeb.Plug.GraphqlPipeline
 
     forward "/", Absinthe.Plug, schema: ConsoleWeb.Schema
-  end
-
-  scope "/api", ConsoleWeb do
-    pipe_through :no_organization
-
-    get "/organizations", OrganizationController, :index
   end
 
   scope "/api", ConsoleWeb do
@@ -57,7 +45,7 @@ defmodule ConsoleWeb.Router do
     post "/labels/debug", LabelController, :debug
     resources "/gateways", GatewayController, except: [:new, :edit]
     resources "/channels", ChannelController, except: [:new, :edit]
-    resources "/organizations", OrganizationController, except: [:new, :edit, :index] do
+    resources "/organizations", OrganizationController, except: [:new, :edit] do
       post "/switch", OrganizationController, :switch
     end
 


### PR DESCRIPTION
Getting your current orgs doesn't expect you to have a current organization supplied anymore.