### PR TITLE
Add device with no devices

### DIFF
--- a/assets/js/components/devices/DeviceIndex.jsx
+++ b/assets/js/components/devices/DeviceIndex.jsx
@@ -119,8 +119,7 @@ class DeviceIndex extends Component {
       showDevicesRemoveLabelModal,
       showDeviceRemoveAllLabelsModal,
       labelsSelected,
-      deviceToRemoveLabel,
-      hasDevices
+      deviceToRemoveLabel
     } = this.state
 
     const { devices, loading, error } = this.props.data

--- a/assets/js/components/devices/DeviceIndexTable.jsx
+++ b/assets/js/components/devices/DeviceIndexTable.jsx
@@ -5,9 +5,6 @@ import get from 'lodash/get'
 import LabelTag from '../common/LabelTag'
 import UserCan from '../common/UserCan'
 import { redForTablesDeleteText } from '../../util/colors'
-import { PAGINATED_DEVICES, DEVICE_SUBSCRIPTION } from '../../graphql/devices'
-import analyticsLogger from '../../util/analyticsLogger'
-import { graphql } from 'react-apollo';
 import DevicesImg from '../../../img/devices.svg'
 
 import classNames from 'classnames';


### PR DESCRIPTION
This reworks the device addition prompt to be in the center of the screen when there are no devices.