### PR TITLE
Display spinner for device import until complete

### DIFF
--- a/assets/js/components/devices/DeviceIndex.jsx
+++ b/assets/js/components/devices/DeviceIndex.jsx
@@ -58,6 +58,7 @@ class DeviceIndex extends Component {
     column: DEFAULT_COLUMN,
     order: DEFAULT_ORDER,
     allDevicesSelected: false,
+    importComplete: false
   }
 
   componentDidMount() {
@@ -102,6 +103,7 @@ class DeviceIndex extends Component {
             device${(updatedImport.successful_devices !== 1 && "s") || ""} from ${
               updatedImport.type === "ttn" ? "The Things Network." : "CSV."
             }. Refresh this page to see the changes.`);
+            this.setState({ importComplete: true })
           } else if (updatedImport.status === "failed"){
             displayError(`Failed to import devices from ${
               updatedImport.type === "ttn" ? "The Things Network" : "CSV"
@@ -179,7 +181,7 @@ class DeviceIndex extends Component {
   }
 
   closeImportDevicesModal = () => {
-    this.setState({ showImportDevicesModal: false });
+    this.setState({ showImportDevicesModal: false, importComplete: false });
   }
 
   closeDeleteDeviceModal = () => {
@@ -227,7 +229,8 @@ class DeviceIndex extends Component {
       showDevicesRemoveLabelModal,
       showDeviceRemoveAllLabelsModal,
       labelsSelected,
-      deviceToRemoveLabel
+      deviceToRemoveLabel,
+      importComplete
     } = this.state
 
     const { devices, loading, error } = this.props.devicesQuery;
@@ -291,7 +294,7 @@ class DeviceIndex extends Component {
 
         <NewDeviceModal open={showCreateDeviceModal} onClose={this.closeCreateDeviceModal}/>
 
-        <ImportDevicesModal open={showImportDevicesModal} onClose={this.closeImportDevicesModal}/>
+        <ImportDevicesModal open={showImportDevicesModal} onClose={this.closeImportDevicesModal} importComplete={importComplete}/>
 
         <DevicesAddLabelModal
           open={showDevicesAddLabelModal}

--- a/assets/js/components/devices/import/ImportDevicesModal.jsx
+++ b/assets/js/components/devices/import/ImportDevicesModal.jsx
@@ -9,9 +9,10 @@ import { fetchTtnDevices, importTtnDevices, importGenericDevices, resetGenericDe
 import ChooseImportType from './ChooseImportType';
 import ShowDeviceData from './generic/ShowDeviceData';
 import GetApplications from './ttn/GetApplications';
-import { Modal, Spin } from 'antd';
+import { Modal, Spin, Typography } from 'antd';
 import { LoadingOutlined } from '@ant-design/icons';
 import analyticsLogger from '../../../util/analyticsLogger';
+const { Text, Title } = Typography
 
 const antLoader = <LoadingOutlined style={{ fontSize: 50, color: 'white' }} spin />;
 const antLoaderGrey = <LoadingOutlined style={{ fontSize: 50, color: 'grey' }} spin />
@@ -33,7 +34,8 @@ const ImportDevicesModal = (props) => {
     importTtnDevices,
     ttnAuthorizationCode,
     importGenericDevices,
-    resetGenericDeviceImport
+    resetGenericDeviceImport,
+    importComplete
   } = props;
   const [ importType, setImportType ] = useState('');
   const {
@@ -50,16 +52,6 @@ const ImportDevicesModal = (props) => {
     analyticsLogger.logEvent("ACTION_GENERIC_IMPORT", { withLabel });
     importGenericDevices(scannedGenericDevices, withLabel);
   }
-
-  useEffect(() => {
-    if (importStarted) {
-      onClose();
-      setTimeout(() => {
-        resetGenericDeviceImport();
-        setImportType('');
-      }, 500);
-    }
-  }, [importStarted]);
 
   return (
     <Modal
@@ -130,7 +122,12 @@ const ImportDevicesModal = (props) => {
           importType === 'csv' && (
             (genericImportScanned &&
             <ShowDeviceData numDevices={scannedGenericDevices.length} onImport={handleImport}/>) ||
-            <Spin indicator={antLoaderGrey}/>
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: 20 }}>
+              <Title style={{width: '100%', textAlign: 'center'}}>Import Status</Title>
+              {importStarted && !importComplete && <Spin indicator={antLoaderGrey} style={{ marginBottom: 20 }}/>}
+              {importStarted && !importComplete && <Text style={{ textAlign: 'center' }}>Please wait while your import is being completed.</Text>}
+              {importComplete && <Text style={{ textAlign: 'center' }}>Your import is complete, please refresh the page to see your devices.</Text>}
+            </div>
           )
         )
       }


### PR DESCRIPTION
Before this PR, device import modal will be dismissed when import starts automatically.

This PR changes the behavior so that the modal spins during device import and changes to a success messsage when import is complete. The user will have to dismiss the modal manually. 
