### PR TITLE
Add Organization not to show for manager on top bar menu

### DIFF
--- a/assets/js/components/common/TopBar.jsx
+++ b/assets/js/components/common/TopBar.jsx
@@ -18,7 +18,7 @@ import Logo from '../../../img/logo-horizontalwhite-symbol.svg'
 import ProfileActive from '../../../img/topbar-pf-active.svg'
 import ProfileInactive from '../../../img/topbar-pf-inactive.svg'
 import { switchOrganization } from '../../actions/organization';
-import { OrganizationMenu } from '../organizations/OrganizationMenu';
+import OrganizationMenu from '../organizations/OrganizationMenu';
 import NewOrganizationModal from '../organizations/NewOrganizationModal';
 
 const queryOptions = {

--- a/assets/js/components/organizations/OrganizationMenu.jsx
+++ b/assets/js/components/organizations/OrganizationMenu.jsx
@@ -1,23 +1,34 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { Icon, Menu } from 'antd';
 import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
 
-export const OrganizationMenu = props => {
-  const { current, orgs, handleClick, ...rest } = props;
+@connect(mapStateToProps, null)
+class OrganizationMenu extends Component {
+  render() {
+    const { current, orgs, handleClick, role, ...rest } = this.props;
+    return (
+      <Menu {...rest} onClick={handleClick}>
+        <Menu.ItemGroup title="Current Organization">
+          <Menu.Item key='current'><Link to="/organizations">{current}</Link></Menu.Item>
+        </Menu.ItemGroup>
+        {orgs.length > 0 && <Menu.Divider /> && 
+        <Menu.ItemGroup title="Switch Organization">
+          {orgs.map(org => (
+            <Menu.Item key={org.id}>{org.name}</Menu.Item>
+          ))}
+        </Menu.ItemGroup>} 
+        {role === 'admin' && <Menu.Divider />}
+        {role === 'admin' && <Menu.Item key='new'><Icon type="plus" /> New Organization</Menu.Item>}
+      </Menu>
+    );
+  }
+}
 
-  return (
-    <Menu {...rest} onClick={handleClick}>
-      <Menu.ItemGroup title="Current Organization">
-        <Menu.Item key='current'><Link to="/organizations">{current}</Link></Menu.Item>
-      </Menu.ItemGroup>
-      {orgs.length > 0 && <Menu.Divider /> && 
-      <Menu.ItemGroup title="Switch Organization">
-        {orgs.map(org => (
-          <Menu.Item key={org.id}>{org.name}</Menu.Item>
-        ))}
-      </Menu.ItemGroup>} 
-      <Menu.Divider />
-      <Menu.Item key='new'><Icon type="plus" /> New Organization</Menu.Item>
-    </Menu>
-  );
-};
+function mapStateToProps(state) {
+  return {
+    role: state.organization.currentRole
+  }
+}
+
+export default OrganizationMenu


### PR DESCRIPTION
As a manager, I should not be able to see option to add organization from top bar menu.

`Menu` component buggy when inserting the other menu components as children when wrapped around by another component :/ which is why I checked for the condition separately instead of wrapping them... this is likely fixed by latest antd package so I was thinking it can be updated then

tests passing:
```
......................................

Finished in 1.0 seconds
40 tests, 0 failures
```