### PR TITLE
Fix update for adafruit 

### DIFF
--- a/assets/js/components/channels/forms/MQTTForm.jsx
+++ b/assets/js/components/channels/forms/MQTTForm.jsx
@@ -50,7 +50,7 @@ class MQTTForm extends Component {
           uplink: {
             topic: uplinkTopic || 'helium/{{device_id}}/rx'
           },
-          ...!endpoint.includes('adafruit') && { downlink: {
+          ...!endpoint.includes('@io.adafruit.com') && { downlink: {
             topic: downlinkTopic || 'helium/{{device_id}}/tx'
           }}
         })


### PR DESCRIPTION
bug because on update, the form used is the standard MQTT form which I didn't account for updating the downlink if it's empty, so the easiest way I could figure out to solve it is to conditionally pass the downlink in the payload if the endpoint does NOT contain the adafruit url

tests passing
```
........................................

Finished in 1.0 seconds
40 tests, 0 failures
```