### PR TITLE
Link docs throughout console

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -461,3 +461,20 @@ a.version-link {
   color: #1b1f23;
   padding: 6px 12px;
 }
+
+p.page-description {
+  font-size: 16px;
+  margin-bottom: 20px;
+  max-width: 600px;
+  margin-top: -30px;
+  padding-left: 4px;
+  font-weight: 300px;
+  position: relative;
+}
+
+.blankstateWrapper {
+  width: 100%;
+  padding-top: 100px;
+  margin: 0 auto;
+  position: relative;
+}

--- a/assets/js/components/billing/DataCreditsIndex.jsx
+++ b/assets/js/components/billing/DataCreditsIndex.jsx
@@ -122,7 +122,7 @@ class DataCreditsIndex extends Component {
   renderBlankState = () => {
     const { organization } = this.props.data
     return (
-      <div className="blankstateWrapper">
+      <div className="blankstateWrapper" style={{ paddingTop: "80px" }}>
         <div className="message">
           <img style={{width: 100, marginBottom: 20}} src={DCIMg} />
           <h1>Data Credits</h1>
@@ -198,12 +198,6 @@ class DataCreditsIndex extends Component {
               max-width: 500px;
               margin-bottom: 20px;
             }
-            .blankstateWrapper {
-              width: 100%;
-              padding-top: 80px;
-              margin: 0 auto;
-              position: relative;
-            }
           `}</style>
       </div>
     )
@@ -216,21 +210,13 @@ class DataCreditsIndex extends Component {
 
     return (
       <div>
+        <p className="page-description" style={{ maxWidth: "450px" }}>
+          Data Credits (also known as DCs) are used to pay all transaction fees on the Helium Network. <a href="https://developer.helium.com/longfi/data-credits" target="_blank"> Tell me more about Data Credits.</a>
+        </p>
         <Row gutter={16}>
           <Col span={8}>
             <Card
               title="Remaining Data Credits"
-              extra={
-                <Popover
-                  content="Data Credits - known as DCs - are used to pay all transaction fees on the Helium Network."
-                  placement="bottom"
-                  overlayStyle={{ width: 220 }}
-                >
-                  <Link to="#">
-                    <Text style={styles.tipText}>What are Data Credits?</Text>
-                  </Link>
-                </Popover>
-              }
               bodyStyle={{ ...styles.cardBody, minWidth: 300 }}
               style={{ overflow: 'hidden' }}
             >

--- a/assets/js/components/channels/ChannelIndex.jsx
+++ b/assets/js/components/channels/ChannelIndex.jsx
@@ -34,7 +34,10 @@ class ChannelIndex extends Component {
     const { showDeleteChannelModal, channel } = this.state
     return (
       <DashboardLayout title="Integrations" user={this.props.user}>
-      <p style={{fontSize: 16, marginBottom: 60, maxWidth: 600, marginTop: '-30px', paddingLeft: 4, fontWeight: 300}}>Integrations enable devices to connect to pre-configured, cloud-based applications or send data directly over HTTP or MQTT.</p>
+      <p style={{fontSize: 16, marginBottom: 20, maxWidth: 600, marginTop: '-30px', paddingLeft: 4, fontWeight: 300}}>
+        Integrations enable devices to connect to pre-configured, cloud-based applications or send data directly over HTTP or MQTT.
+        <a href="https://developer.helium.com/console/integrations" target="_blank"> Tell me more about Console Integrations.</a>
+      </p>
       <div className="flexwrapper">
         <UserCan>
           <Card title="Add a Prebuilt Integration" className="integrationcard">

--- a/assets/js/components/channels/ChannelsTable.jsx
+++ b/assets/js/components/channels/ChannelsTable.jsx
@@ -113,103 +113,46 @@ class ChannelsTable extends Component {
     const { channels, loading, error } = this.props.data
 
     if (loading) return <SkeletonLayout />;
-    if (error) return (
-      <div className="blankstateWrapper">
-        <div className="message">
-        <h1>You have no Integrations added</h1>
-        <p>Choose an Integration above to get started.</p>
-
-        </div>
-      <style jsx>{`
-
-          .message {
-
-            width: 100%;
-            max-width: 500px;
-            margin: 0 auto;
-            text-align: center;
-
-          }
-
-          h1, p  {
-
-            color: #242425;
-          }
-          h1 {
-            font-size: 30px;
-            margin-bottom: 10px;
-          }
-          p {
-            font-size: 16px;
-            font-weight: 300;
-            opacity: 0.75;
-          }
-
-
-          .blankstateWrapper {
-            width: 100%;
-            padding-top: 100px;
-            padding-bottom: 100px;
-            margin: 0 auto;
-            position: relative;
-
-
-          }
-        `}</style>
-
-      </div>
-    )
+    if (error) return <Text>Data failed to load, please reload the page and try again</Text>;
 
     return (
       <div>
-      {
-          channels.entries.length === 0 && (
+        { channels.entries.length === 0 && (
+          <div className="blankstateWrapper" style={{ paddingBottom: "100px" }}>
+            <div className="message">
+              <h1>You have no Integrations added</h1>
+              <p>Choose an Integration above to get started.</p>
+              <p>More details about adding Integrations can be found <a href="https://developer.helium.com/console/integrations" target="_blank"> here.</a></p>
+            </div>
+            <style jsx>{`
 
-             <div className="blankstateWrapper">
-      <div className="message">
-<h1>You have no Integrations added</h1>
-<p>Choose an Integration above to get started.</p>
+                .message {
 
-      </div>
-      <style jsx>{`
+                  width: 100%;
+                  max-width: 500px;
+                  margin: 0 auto;
+                  text-align: center;
 
-          .message {
+                }
 
-            width: 100%;
-            max-width: 500px;
-            margin: 0 auto;
-            text-align: center;
+                h1, p  {
 
-          }
-
-          h1, p  {
-
-            color: #242425;
-          }
-          h1 {
-            font-size: 30px;
-            margin-bottom: 10px;
-          }
-          p {
-            font-size: 16px;
-            font-weight: 300;
-            opacity: 0.75;
-          }
-
-
-          .blankstateWrapper {
-            width: 100%;
-            padding-top: 100px;
-            padding-bottom: 100px;
-            margin: 0 auto;
-            position: relative;
-          }
-        `}</style>
-      </div>
-      )
-      }
-      {
-        channels.entries.length > 0 && (
+                  color: #242425;
+                }
+                h1 {
+                  font-size: 30px;
+                  margin-bottom: 10px;
+                }
+                p {
+                  font-size: 16px;
+                  font-weight: 300;
+                  opacity: 0.75;
+                }
+              `}
+            </style>
+          </div>
+        )}
+        { channels.entries.length > 0 && (
           <React.Fragment>
             <Table
               onRow={(record, rowIndex) => ({
@@ -230,9 +173,7 @@ class ChannelsTable extends Component {
               />
             </div>
           </React.Fragment>
-        )
-        }
-
+        )}
       </div>
     )
   }

--- a/assets/js/components/channels/IntegrationTypeTileSimple.jsx
+++ b/assets/js/components/channels/IntegrationTypeTileSimple.jsx
@@ -5,7 +5,7 @@ import { NEW_CHANNEL_TYPES, PREMADE_CHANNEL_TYPES } from '../../util/integration
 
 export const IntegrationTypeTileSimple = props => {
   const { type } = props;
-  const { img, name } = [...NEW_CHANNEL_TYPES, ...PREMADE_CHANNEL_TYPES].filter(channel => channel.link.includes(type))[0];
+  const { img, name, info, docLink } = [...NEW_CHANNEL_TYPES, ...PREMADE_CHANNEL_TYPES].filter(channel => channel.link.includes(type))[0];
 
   return (
     <div>
@@ -13,6 +13,9 @@ export const IntegrationTypeTileSimple = props => {
       <Text strong>
         {name}
       </Text>
+      <div style={{ paddingTop: '10px', maxWidth: '500px' }}>
+        <Text>{info} <a href={docLink} target="_blank">Tell me more about setting up this Integration.</a></Text>
+      </div>
     </div>
   );
 };

--- a/assets/js/components/channels/forms/MyDevicesForm.jsx
+++ b/assets/js/components/channels/forms/MyDevicesForm.jsx
@@ -33,15 +33,7 @@ class MyDevicesForm extends Component {
     return(
       <div>
         <Text>
-          myDevices Cayenne lets you quickly visualize real-time data sent over the Helium Network.
-        </Text>
-        <br />
-        <Text>
           Use a supported device listed on their console or encode the payload with the Cayenne Low Power Payload (Cayenne LPP) format.
-        </Text>
-        <br />
-        <Text>
-          For more integration information, check <a href="http://developer.helium.com/console/integrations" target="_blank">developer.helium.com/console/integrations</a>.
         </Text>
       </div>
     );

--- a/assets/js/components/common/DashboardLayout.jsx
+++ b/assets/js/components/common/DashboardLayout.jsx
@@ -12,33 +12,35 @@ class DashboardLayout extends Component {
 
     return (
       <Layout style={{width: '100%', minWidth: 800 }}>
-      <Header>
-            <TopBar user={user} />
-          </Header>
+        <Header>
+          <TopBar user={user} />
+        </Header>
 
-      <Layout style={{ height: 'calc(100vh - 64px)' }}>
-        {
-          !noSideNav && (
-            <Sider style={{ overflow: 'hidden' }}>
-              <NavDrawer />
-              {
-                process.env.CONSOLE_VERSION && 
-                  <Popover
-                    content="Click to see release details"
-                    placement="right"
-                  >
-                    <Button className="version-link" icon="tool" href="https://engineering.helium.com/" target="_blank">{process.env.CONSOLE_VERSION}</Button>
-                  </Popover>
-              }
-            </Sider>
-          )
-        }
-        <Layout>
-          <Content><ContentLayout title={title} extra={extra} breadCrumbs={breadCrumbs} noHeaderPadding={noHeaderPadding}>
-            {this.props.children}
-          </ContentLayout></Content>
+        <Layout style={{ height: 'calc(100vh - 64px)' }}>
+          {
+            !noSideNav && (
+              <Sider style={{ overflow: 'hidden' }}>
+                <NavDrawer />
+                {
+                  process.env.CONSOLE_VERSION && 
+                    <Popover
+                      content="Click to see release details"
+                      placement="right"
+                    >
+                      <Button className="version-link" icon="tool" href="https://engineering.helium.com/" target="_blank">{process.env.CONSOLE_VERSION}</Button>
+                    </Popover>
+                }
+              </Sider>
+            )
+          }
+          <Layout>
+            <Content>
+              <ContentLayout title={title} extra={extra} breadCrumbs={breadCrumbs} noHeaderPadding={noHeaderPadding}>
+              {this.props.children}
+              </ContentLayout>
+            </Content>
+          </Layout>
         </Layout>
-      </Layout>
       </Layout>
     )
   }

--- a/assets/js/components/devices/DeviceIndex.jsx
+++ b/assets/js/components/devices/DeviceIndex.jsx
@@ -269,6 +269,9 @@ class DeviceIndex extends Component {
           hasDevices && createDeviceButton()
         }
       >
+        {hasDevices && <p className="page-description">
+          Devices can be added to the Helium network. <a href="https://developer.helium.com/console/adding-devices" target="_blank"> Tell me more about adding devices.</a>
+        </p>}
         {
           (error && <Text>Data failed to load, please reload the page and try again</Text>) || (
             loading ? <IndexSkeleton title={title} /> :

--- a/assets/js/components/devices/DeviceIndexTable.jsx
+++ b/assets/js/components/devices/DeviceIndexTable.jsx
@@ -264,6 +264,10 @@ class DeviceIndexTable extends Component {
               <h1>No Devices</h1>
               <p>You haven’t added any devices yet.</p>
               { noDevicesButton() }
+              <div className="explainer">
+                <p>Devices can be added to the Helium network.</p>
+                <p>More details about adding devices can be found <a href="https://developer.helium.com/longfi/data-credits" target="_blank"> here.</a></p>
+              </div>
             </div>
             <style jsx>{`
 
@@ -274,6 +278,25 @@ class DeviceIndexTable extends Component {
                   margin: 0 auto;
                   text-align: center;
 
+                }
+
+                .explainer {
+                  padding: 20px 60px 1px 60px;
+                  border-radius: 20px;
+                  text-align: center;
+                  margin-top: 50px;
+                  box-sizing: border-box;
+      border: none;
+      background: #F6F8FA;
+                }
+
+                .explainer p {
+                  color: #565656;
+                  font-size: 15px;
+                }
+    
+                .explainer p a {
+                  color: #096DD9;
                 }
 
                 h1, p  {
@@ -290,17 +313,6 @@ class DeviceIndexTable extends Component {
                   font-size: 20px;
                   font-weight: 300;
                   margin-bottom: 30px;
-                }
-
-
-                .blankstateWrapper {
-                  width: 100%;
-                  padding-top: 200px;
-                  margin: 0 auto;
-                  position: relative;
-                  padding-bottom: 200px;
-
-
                 }
               `}</style>
             </div>

--- a/assets/js/components/functions/FunctionIndexTable.jsx
+++ b/assets/js/components/functions/FunctionIndexTable.jsx
@@ -10,7 +10,6 @@ import { PAGINATED_FUNCTIONS, FUNCTION_SUBSCRIPTION } from '../../graphql/functi
 import analyticsLogger from '../../util/analyticsLogger'
 import { graphql } from 'react-apollo';
 import FunctionsImg from '../../../img/functions.svg'
-import classNames from 'classnames';
 import { Table, Button, Pagination, Typography, Card, Switch } from 'antd';
 import { IndexSkeleton } from '../common/IndexSkeleton';
 
@@ -172,18 +171,16 @@ class FunctionIndexTable extends Component {
     <div className="explainer">
       <h2>What are Functions?</h2>
       <p>Functions are operators that can be applied to <a href="/labels">Labels</a> and act on the data of any <a href="/devices">devices</a> in those Labels.</p>
+      <p>More details can be found <a href="https://developer.helium.com/console/functions" target="_blank">here</a>.</p>
     </div>
 
           </div>
           <style jsx>{`
-
              .message {
-
                 width: 100%;
                 max-width: 500px;
                 margin: 0 auto;
                 text-align: center;
-
               }
 
               .explainer {
@@ -192,9 +189,8 @@ class FunctionIndexTable extends Component {
                 text-align: center;
                 margin-top: 50px;
                 box-sizing: border-box;
-                
-                  border: none;
-  background: #F6F8FA;
+                border: none;
+                background: #F6F8FA;
               }
 
               .explainer h2 {
@@ -210,8 +206,7 @@ class FunctionIndexTable extends Component {
                 color: #096DD9;
               }
 
-              h1, p  {
-
+              h1, p {
                 color: #242425;
               }
               h1 {
@@ -224,14 +219,6 @@ class FunctionIndexTable extends Component {
                 font-size: 20px;
                 font-weight: 300;
               }
-
-
-              .blankstateWrapper {
-                width: 100%;
-                padding-top: 150px;
-                margin: 0 auto;
-                position: relative;
-              }
             `}</style>
 
           </div>
@@ -239,6 +226,10 @@ class FunctionIndexTable extends Component {
         }
         {
           functions.entries.length > 0 && (
+            <div>
+              <p className="page-description">
+                Functions are operators that can be applied to Labels and act on the data of any devices in those Labels. <a href="https://developer.helium.com/console/functions" target="_blank"> Tell me more about functions.</a>
+              </p>
             <Card
         bodyStyle={{ padding: 0, paddingTop: 1, overflowX: 'scroll' }}
         title={`${functions.totalEntries} Functions`}
@@ -264,6 +255,7 @@ class FunctionIndexTable extends Component {
               </div>
             </React.Fragment>
             </Card>
+            </div>
           )
         }
       </div>

--- a/assets/js/components/labels/LabelIndexTable.jsx
+++ b/assets/js/components/labels/LabelIndexTable.jsx
@@ -165,6 +165,7 @@ class LabelIndexTable extends Component {
         <h2>What are Labels?</h2>
         <p>Labels allow you to organise your devices into groups. Devices can have many Labels that describe different aspects of it.</p>
         <p>Labels are also used to apply <a href="/integrations">Integrations</a> and <a href="/functions">Functions</a> to devices. </p>
+        <p>More details can be found <a href="https://developer.helium.com/console/labels" target="_blank">here</a>.</p>
       </div>
 
             </div>
@@ -216,22 +217,16 @@ class LabelIndexTable extends Component {
                   font-size: 20px;
                   font-weight: 300;
                 }
-
-
-                .blankstateWrapper {
-                  width: 100%;
-                  padding-top: 100px;
-                  margin: 0 auto;
-                  position: relative;
-
-
-                }
               `}</style>
 
             </div>
           )
         }
         {labels.entries.length > 0 && (
+          <div>
+            <p className="page-description">
+              Labels are a powerful mechanism to organize devices, assign integrations, and provide scalability and flexibility to managing your projects. <a href="https://developer.helium.com/console/labels" target="_blank"> Tell me more about Labels.</a>
+            </p>
           <Card
         bodyStyle={{ padding: 0, paddingTop: 1, overflowX: 'scroll' }}
         title={`${labels.totalEntries} ${labels.totalEntries == 1 ? "Label" : "Labels"}`}
@@ -272,6 +267,7 @@ class LabelIndexTable extends Component {
             </div>
           </React.Fragment>
           </Card>
+          </div>
         )}
       </div>
     )

--- a/assets/js/components/organizations/OrganizationIndex.jsx
+++ b/assets/js/components/organizations/OrganizationIndex.jsx
@@ -56,6 +56,9 @@ class OrganizationIndex extends Component {
           </UserCan>
         }
       >
+        <p className="page-description">
+          Organizations help keep related projects together. <a href="https://developer.helium.com/console/users#organizations" target="_blank"> Tell me more about organizations.</a>
+        </p>
         <Card title="Organizations" bodyStyle={{padding:'0', paddingTop: 1, overflowX: 'scroll' }}>
           <OrganizationsTable
             openDeleteOrganizationModal={this.openDeleteOrganizationModal}

--- a/assets/js/components/organizations/UserIndex.jsx
+++ b/assets/js/components/organizations/UserIndex.jsx
@@ -84,6 +84,9 @@ class UserIndex extends Component {
           </UserCan>
         }
       >
+        <p className="page-description">
+          Console users can be added to organizations and have different roles which dictate their access. <a href="https://developer.helium.com/console/users" target="_blank"> Tell me more about users.</a>
+        </p>
         <Card
           title="Members"
           bodyStyle={{padding:'0', paddingTop: 1, paddingBottom: 0, overflowX: 'scroll' }}

--- a/assets/js/util/integrationInfo.js
+++ b/assets/js/util/integrationInfo.js
@@ -8,15 +8,50 @@ import MyDevices from '../../img/mydevices.svg'
 import Adafruit from '../../img/adafruitio.svg';
 
 export const NEW_CHANNEL_TYPES = [
-  { name: "HTTP", link: "/integrations/new/http", img: `${Http}` },
-  { name: "MQTT", link: "/integrations/new/mqtt", img: `${Mqtt}` },
-  { name: "AWS IoT Core", link: "/integrations/new/aws", img: `${Aws}`},
+  { 
+    name: "HTTP", 
+    link: "/integrations/new/http", 
+    img: `${Http}`, 
+    info: "This integration allows for sending data to an endpoint, as well as receiving data, over HTTP.", 
+    docLink: 'https://developer.helium.com/console/integrations/http' 
+  },
+  { 
+    name: "MQTT", 
+    link: "/integrations/new/mqtt", 
+    img: `${Mqtt}`,
+    info: "This Integration allows for sending data to an endpoint, as well as receiving data, over the MQTT protocol.",
+    docLink: "https://developer.helium.com/console/integrations/mqtt" },
+  { 
+    name: "AWS IoT Core", 
+    link: "/integrations/new/aws", 
+    img: `${Aws}`,
+    info: "This Integration automates the complexity of securely connecting your devices to AWS IoT Core.",
+    docLink: "https://developer.helium.com/console/integrations/awsiotcore"
+  },
   // { name: "Azure IoT", link: "/integrations/new/azure", img: `${Azure}`, inactive: true },
   // { name: "Google IoT", link: "/integrations/new/google", img: `${Google}`, inactive: true },
 ]
 
 export const PREMADE_CHANNEL_TYPES = [
-  { name: "Helium Cargo", link: "/integrations/new/cargo", img: `${Cargo}` },
-  { name: "myDevices Cayenne", link: "/integrations/new/mydevices", img: `${MyDevices}` },
-  { name: "Adafruit IO", link: "/integrations/new/adafruit", img: `${Adafruit}` },
+  { 
+    name: "Helium Cargo", 
+    link: "/integrations/new/cargo", 
+    img: `${Cargo}`,
+    info: "Cargo is an in-house mapping tool used at Helium.",
+    docLink: "https://developer.helium.com/console/integrations/cargo"
+  },
+  { 
+    name: "myDevices Cayenne", 
+    link: "/integrations/new/mydevices", 
+    img: `${MyDevices}`,
+    info: "myDevices Cayenne lets you quickly visualize real-time data sent over the Helium Network.",
+    docLink: "https://developer.helium.com/console/integrations/mydevices-cayenne-integration"
+  },
+  { 
+    name: "Adafruit IO", 
+    link: "/integrations/new/adafruit", 
+    img: `${Adafruit}` ,
+    info: "This Integration automates the complexity of securely connecting your devices to Adafruit IO.",
+    docLink: "https://developer.helium.com/console/integrations/adafruitio"
+  }
 ]


### PR DESCRIPTION
Pages will now have a description with a link to the docs specific section. Integrations will also have the same.

examples:
![image](https://user-images.githubusercontent.com/51131939/100937317-b2454900-34a7-11eb-89a1-50ab590b82aa.png)

![image](https://user-images.githubusercontent.com/51131939/100937347-c1c49200-34a7-11eb-9a6e-e9392d3f0d36.png)

2nd part of this will be to add a footer with more links, in a separate ticket/PR


Tests passing 👍 
```

........................................

Finished in 1.1 seconds
40 tests, 0 failures
```