### PR TITLE
fix link for devices docs

### DIFF
--- a/assets/js/components/devices/DeviceIndexTable.jsx
+++ b/assets/js/components/devices/DeviceIndexTable.jsx
@@ -266,7 +266,7 @@ class DeviceIndexTable extends Component {
               { noDevicesButton() }
               <div className="explainer">
                 <p>Devices can be added to the Helium network.</p>
-                <p>More details about adding devices can be found <a href="https://developer.helium.com/longfi/data-credits" target="_blank"> here.</a></p>
+                <p>More details about adding devices can be found <a href="https://developer.helium.com/console/adding-devices" target="_blank"> here.</a></p>
               </div>
             </div>
             <style jsx>{`


### PR DESCRIPTION
In console.helium.com/devices, when No Devices are added yet, the bottom text "More details about adding devices can be found here." redirects the user to the data-credits page. This PR fixes it to go to https://developer.helium.com/console/adding-devices