### PR TITLE
Label input when creating device should allow new label

### DIFF
--- a/assets/js/actions/device.js
+++ b/assets/js/actions/device.js
@@ -15,13 +15,13 @@ export const GENERIC_IMPORT_STARTED = "GENERIC_IMPORT_STARTED";
 export const GENERIC_IMPORT_FAILED = "GENERIC_IMPORT_FAILED";
 export const RESET_GENERIC_IMPORT = "RESET_GENERIC_IMPORT";
 
-export const createDevice = (params, labelId) => {
+export const createDevice = (params, label) => {
   return (dispatch) => {
     const deviceParams = sanitizeParams(params)
 
     rest.post('/api/devices', {
         device: deviceParams,
-        label_id: labelId,
+        label: label,
       })
       .then(response => {})
   }

--- a/assets/js/components/common/LabelAppliedNew.jsx
+++ b/assets/js/components/common/LabelAppliedNew.jsx
@@ -1,15 +1,16 @@
 import React, { Component } from 'react'
 import { graphql } from 'react-apollo';
 import { SEARCH_LABELS } from '../../graphql/search'
-import { AutoComplete, Select } from 'antd';
-const { Option } = Select;
+import { AutoComplete } from 'antd';
 import find from 'lodash/find'
 import LabelTag from './LabelTag'
-import debounce from 'lodash/debounce'
 
 const queryOptions = {
   options: props => ({
     fetchPolicy: 'cache-and-network',
+    variables: {
+      query: ""
+    }
   })
 }
 
@@ -22,7 +23,6 @@ class LabelAppliedNew extends Component {
   runSearch = (value) => {
     const { loading, fetchMore } = this.props.data
 
-    console.log({value})
     this.props.select(value);
     if (!loading) {
       fetchMore({
@@ -44,40 +44,25 @@ class LabelAppliedNew extends Component {
 
   render() {
     const { searchLabels } = this.state
-    console.log({searchLabels})
-    // const debouncedSearch = debounce(this.runSearch, 300)
 
     return(
-      // <Select
-      //   showSearch
-      //   placeholder="Search or Add Label..."
-      //   onSearch={text => debouncedSearch(text)}
-      //   onSelect={label_id => {
-      //     console.log({label_id})
-      //     this.props.select(label_id)
-      //   }}
-      //   style={{ width: 300, marginBottom: 10 }}
-      //   showArrow={false}
-      //   filterOption={false}
-      //   defaultActiveFirstOption={false}
-      //   notFoundContent={null}
-      //   autoClearSearchValue
-      //   value={this.props.value}
-      // >
-      //   {searchLabels.map(l => (
-      //     <Option value={l.id} key={l.id}>
-      //       <LabelTag text={l.name} color={l.color} hasIntegrations={l.channels.length > 0} hasFunction={find(this.props.allLabels, { id: l.id }).function}/>
-      //     </Option>
-      //   ))}
-      // </Select>
       <AutoComplete
         style={{ width: 300, marginBottom: 10 }}
         options={searchLabels.map(l => (
-          {label: l.name, value: l.id}
+          {
+            label: (
+              <LabelTag 
+                text={l.name} 
+                color={l.color} 
+                hasIntegrations={l.channels.length > 0} 
+                hasFunction={find(this.props.allLabels, { id: l.id }).function}
+              />
+            ), 
+            value: l.name
+          }
         ))}
-        onSelect={label_id => {
-          console.log({label_id})
-          this.props.select(label_id)
+        onSelect={label_name => {
+          this.props.select(label_name)
         }}
         placeholder="Search or Add Label..."
         value={this.props.value}

--- a/assets/js/components/devices/DeviceIndexTable.jsx
+++ b/assets/js/components/devices/DeviceIndexTable.jsx
@@ -107,7 +107,7 @@ class DeviceIndexTable extends Component {
         dataIndex: 'name',
         sorter: true,
         render: (text, record) => (
-          <Link className={record.labels.length === 0 && 'dull'} to={`/devices/${record.id}`}>
+          <Link className={record.labels.length === 0 ? 'dull' : undefined} to={`/devices/${record.id}`}>
             {text} 
             {
               moment().utc().local().subtract(1, 'days').isBefore(moment.utc(record.last_connected).local()) && 

--- a/assets/js/components/devices/NewDeviceModal.jsx
+++ b/assets/js/components/devices/NewDeviceModal.jsx
@@ -11,6 +11,7 @@ import { Modal, Button, Typography, Input, Select, Divider } from 'antd';
 import LabelAppliedNew from '../common/LabelAppliedNew';
 const { Text } = Typography
 const { Option } = Select
+import find from 'lodash/find'
 
 const queryOptions = {
   options: props => ({
@@ -28,7 +29,7 @@ class NewDeviceModal extends Component {
     devEUI: randomString(16),
     appEUI: randomString(16),
     appKey: randomString(32),
-    labelId: null,
+    labelName: null,
   }
 
   componentDidUpdate(prevProps) {
@@ -38,7 +39,7 @@ class NewDeviceModal extends Component {
         devEUI: randomString(16),
         appEUI: randomString(16),
         appKey: randomString(32),
-        labelId: null,
+        labelName: null,
       })
       if (this.nameInputRef.current) {
         this.nameInputRef.current.focus()
@@ -52,10 +53,12 @@ class NewDeviceModal extends Component {
 
   handleSubmit = (e) => {
     e.preventDefault();
-    const { name, devEUI, appEUI, appKey, labelId } = this.state;
+    const { name, devEUI, appEUI, appKey, labelName } = this.state;
     if (devEUI.length === 16 && appEUI.length === 16 && appKey.length === 32)  {
       analyticsLogger.logEvent("ACTION_CREATE_DEVICE", {"name": name, "devEUI": devEUI, "appEUI": appEUI, "appKey": appKey})
-      this.props.createDevice({ name, dev_eui: devEUI.toUpperCase(), app_eui: appEUI.toUpperCase(), app_key: appKey.toUpperCase() }, labelId)
+      let foundLabel = find(this.props.data.allLabels, { name: labelName });
+      let label = foundLabel ? { labelApplied: foundLabel.id } : { newLabel: labelName };
+      this.props.createDevice({ name, dev_eui: devEUI.toUpperCase(), app_eui: appEUI.toUpperCase(), app_key: appKey.toUpperCase() }, label)
 
       this.props.onClose()
     } else {
@@ -66,7 +69,6 @@ class NewDeviceModal extends Component {
   render() {
     const { open, onClose } = this.props
     const { allLabels, error } = this.props.data
-    console.log(this.state.labelId)
 
     return (
       <Modal
@@ -139,8 +141,8 @@ class NewDeviceModal extends Component {
         <Text style={{marginTop: 30, display: 'block'}} strong>Attach a Label (Optional)</Text>
         <LabelAppliedNew 
           allLabels={allLabels} 
-          value={this.state.labelId} 
-          select={value => this.setState({ labelId: value })} 
+          value={this.state.labelName} 
+          select={value => this.setState({ labelName: value })} 
         />
       </Modal>
     )


### PR DESCRIPTION
In this PR, the device creation modal allows label creation (previously restricted to selecting only an existing label). By doing so it gets rid of bug that kept the previously attached label in state after exiting the modal.


Tests
```
..............................................

Finished in 2.4 seconds
48 tests, 0 failures
```