### PR TITLE
Pagination size selector not working

### DIFF
--- a/assets/js/components/billing/DataCreditPurchasesTable.jsx
+++ b/assets/js/components/billing/DataCreditPurchasesTable.jsx
@@ -159,6 +159,7 @@ class DataCreditPurchasesTable extends Component {
             total={dcPurchases.totalEntries}
             onChange={page => this.handleChangePage(page)}
             style={{marginBottom: 20}}
+            showSizeChanger={false}
           />
         </div>
       </Card>

--- a/assets/js/components/channels/ChannelsTable.jsx
+++ b/assets/js/components/channels/ChannelsTable.jsx
@@ -185,6 +185,7 @@ class ChannelsTable extends Component {
                 total={channels.totalEntries}
                 onChange={page => this.handleChangePage(page)}
                 style={{marginBottom: 20}}
+                showSizeChanger={false}
               />
             </div>
           </React.Fragment>

--- a/assets/js/components/devices/DeviceIndexTable.jsx
+++ b/assets/js/components/devices/DeviceIndexTable.jsx
@@ -422,6 +422,7 @@ class DeviceIndexTable extends Component {
                   total={devices.totalEntries}
                   onChange={page => this.handleChangePage(page)}
                   style={{marginBottom: 20}}
+                  showSizeChanger={false}
                 />
               </div>
             </React.Fragment>

--- a/assets/js/components/devices/DeviceShowLabelsTable.jsx
+++ b/assets/js/components/devices/DeviceShowLabelsTable.jsx
@@ -197,6 +197,7 @@ class DeviceShowLabelsTable extends Component {
             total={labels_by_device.totalEntries}
             onChange={page => this.handleChangePage(page)}
             style={{marginBottom: 20}}
+            showSizeChanger={false}
           />
         </div>
       </Card>

--- a/assets/js/components/functions/FunctionIndexTable.jsx
+++ b/assets/js/components/functions/FunctionIndexTable.jsx
@@ -256,6 +256,7 @@ class FunctionIndexTable extends Component {
                   total={functions.totalEntries}
                   onChange={page => this.handleChangePage(page)}
                   style={{marginBottom: 20}}
+                  showSizeChanger={false}
                 />
               </div>
             </React.Fragment>

--- a/assets/js/components/labels/LabelIndexTable.jsx
+++ b/assets/js/components/labels/LabelIndexTable.jsx
@@ -285,6 +285,7 @@ class LabelIndexTable extends Component {
                 total={labels.totalEntries}
                 onChange={page => this.handleChangePage(page)}
                 style={{marginBottom: 20}}
+                showSizeChanger={false}
               />
             </div>
           </React.Fragment>

--- a/assets/js/components/labels/LabelShowTable.jsx
+++ b/assets/js/components/labels/LabelShowTable.jsx
@@ -244,6 +244,7 @@ class LabelShowTable extends Component {
             total={devices_by_label.totalEntries}
             onChange={page => this.handleChangePage(page)}
             style={{marginBottom: 20}}
+            showSizeChanger={false}
           />
         </div>
       </Card>

--- a/assets/js/components/organizations/InvitationsTable.jsx
+++ b/assets/js/components/organizations/InvitationsTable.jsx
@@ -119,6 +119,7 @@ class InvitationsTable extends Component {
             total={invitations.totalEntries}
             onChange={page => this.handleChangePage(page)}
             style={{ marginBottom: 20 }}
+            showSizeChanger={false}
           />
         </div>
       </div>

--- a/assets/js/components/organizations/MembersTable.jsx
+++ b/assets/js/components/organizations/MembersTable.jsx
@@ -140,6 +140,7 @@ class MembersTable extends Component {
             total={memberships.totalEntries}
             onChange={page => this.handleChangePage(page)}
             style={{ marginBottom: 20 }}
+            showSizeChanger={false}
           />
         </div>
       </div>

--- a/assets/js/components/organizations/OrganizationsTable.jsx
+++ b/assets/js/components/organizations/OrganizationsTable.jsx
@@ -180,6 +180,7 @@ class OrganizationsTable extends Component {
             total={organizations.totalEntries}
             onChange={page => this.handleChangePage(page)}
             style={{marginBottom: 20}}
+            showSizeChanger={false}
           />
         </div>
       </div>


### PR DESCRIPTION
Per ant design documentation:
![image](https://user-images.githubusercontent.com/51131939/108250242-ddd0ea80-710a-11eb-9b3c-7241628c1168.png)

This was causing all the tables using `Pagination` component to have a size selector we are not implementing, thus using it was not doing anything.

I am turning it off since we are using our own selector on Devices pages. If other tables need it, we should use the same one for consistency.