### PR TITLE
Switching org bug

### DIFF
--- a/lib/console/api_keys/api_key.ex
+++ b/lib/console/api_keys/api_key.ex
@@ -31,9 +31,9 @@ defmodule Console.ApiKeys.ApiKey do
 
     api_key
     |> cast(attrs, [:role, :name, :organization_id, :user_id, :key])
-    |> validate_required(:role, message: "Please select a role for your new api key")
+    |> validate_required(:role, message: "Please select a role for your new API key")
     |> validate_inclusion(:role, ~w(admin))
-    |> validate_required(:name, message: "Please choose a name for your new api key")
+    |> validate_required(:name, message: "Please choose a name for your new API key")
     |> validate_length(:name, max: 50, message: "Name cannot be longer than 50 characters")
     |> validate_required([:key, :organization_id, :user_id])
     |> unique_constraint(:name, name: :api_keys_name_organization_id_index, message: "This name has already been used in this organization")

--- a/lib/console/organizations/organizations.ex
+++ b/lib/console/organizations/organizations.ex
@@ -238,7 +238,7 @@ defmodule Console.Organizations do
   end
 
   def update_membership(%Membership{} = membership, attrs) do
-    if attrs["role"] != "admin" do
+    if "role" in attrs and attrs["role"] != "admin" do
       Repo.transaction(fn ->
         from(key in ApiKey, where: key.user_id == ^membership.user_id and key.organization_id == ^membership.organization_id)
         |> Repo.delete_all()


### PR DESCRIPTION
Since `role` is only passed in when the `Membership`'s role is being changed and not when using this function to switch orgs, `role` would not be present in `attrs` and it would always be `true` that `attrs["role"] != "admin"`, thus making it always delete keys when switching orgs.

Tests passing ✅ 
```
................................................

Finished in 1.3 seconds
48 tests, 0 failures
```