### PR TITLE
Pull burn hnt address from router

### DIFF
--- a/assets/js/actions/dataCredits.js
+++ b/assets/js/actions/dataCredits.js
@@ -49,6 +49,10 @@ export const generateMemo = () => () => (
   rest.get('/api/data_credits/generate_memo')
 )
 
+export const getRouterAddress = () => () => (
+  rest.get('/api/data_credits/router_address')
+)
+
 const convertToString = (amount) => {
   if (typeof(amount) === "number") {
     return amount.toString()

--- a/assets/js/components/channels/ChannelShow.jsx
+++ b/assets/js/components/channels/ChannelShow.jsx
@@ -173,7 +173,7 @@ class ChannelShow extends Component {
     if (process.env.SELF_HOSTED && window.env_domain !== "localhost:4000") {
       downlinkUrl = `https://${window.env_domain}/api/v1/down/${channel.id}/${downlinkKey}/{:optional_device_id}`
     }
-    if (!process.env.SELF_HOSTED && process.env.ENV_DOMAIN !== "localhost") {
+    if (!process.env.SELF_HOSTED) {
       downlinkUrl = `https://${process.env.ENV_DOMAIN}/api/v1/down/${channel.id}/${downlinkKey}/{:optional_device_id}`
     }
 

--- a/lib/console/application.ex
+++ b/lib/console/application.ex
@@ -14,6 +14,7 @@ defmodule Console.Application do
       # Start the endpoint when the application starts
       supervisor(ConsoleWeb.Endpoint, []),
       supervisor(Absinthe.Subscription, [ConsoleWeb.Endpoint]),
+      worker(ConsoleWeb.Monitor, [%{}]),
       # Start your own worker by calling: Console.Worker.start_link(arg1, arg2, arg3)
       # worker(Console.Worker, [arg1, arg2, arg3]),
       {Task.Supervisor, name: ConsoleWeb.TaskSupervisor},

--- a/lib/console_web/channels/monitor.ex
+++ b/lib/console_web/channels/monitor.ex
@@ -1,0 +1,13 @@
+defmodule ConsoleWeb.Monitor do
+  def start_link(initial_state) do
+    Agent.start_link(fn -> initial_state end, name: __MODULE__)
+  end
+
+  def get_router_address do
+    Agent.get(__MODULE__, fn state -> state end)
+  end
+
+  def update_router_address(address) do
+    Agent.update(__MODULE__, fn _ -> address end)
+  end
+end

--- a/lib/console_web/channels/organization_channel.ex
+++ b/lib/console_web/channels/organization_channel.ex
@@ -4,4 +4,10 @@ defmodule ConsoleWeb.OrganizationChannel do
   def join("organization:all", _message, socket) do
     {:ok, socket}
   end
+
+  def handle_in("response:update", %{"address" => router_address}, socket) do
+    ConsoleWeb.Monitor.update_router_address(router_address)
+
+    {:noreply, socket}
+  end
 end

--- a/lib/console_web/controllers/data_credit_controller.ex
+++ b/lib/console_web/controllers/data_credit_controller.ex
@@ -303,6 +303,11 @@ defmodule ConsoleWeb.DataCreditController do
     end
   end
 
+  def get_router_address(conn, _) do
+    address = ConsoleWeb.Monitor.get_router_address()
+    conn |> send_resp(:ok, Poison.encode!(%{ address: address }))
+  end
+
   def get_hnt_price(conn, _) do
     with {:ok, current_price_resp} <- HTTPoison.get("https://api.helium.io/v1/oracle/prices/current"),
       200 <- current_price_resp.status_code,

--- a/lib/console_web/router.ex
+++ b/lib/console_web/router.ex
@@ -75,10 +75,11 @@ defmodule ConsoleWeb.Router do
     post "/data_credits/set_automatic_payments", DataCreditController, :set_automatic_payments
     post "/data_credits/transfer_dc", DataCreditController, :transfer_dc
     get "/data_credits/generate_memo", DataCreditController, :generate_memo
+    get "/data_credits/router_address", DataCreditController, :get_router_address
     get "/data_credits/get_hnt_price", DataCreditController, :get_hnt_price
 
     post "/flows/update", FlowsController, :update_edges
-    
+
     post "/clear_downlink_queue", DownlinkController, :clear_downlink_queue
   end
 


### PR DESCRIPTION
With this change, open source console will be able to get the open source router b58 address when router connects to console sockets. Currently, the address is hardcoded and isn't viable for open source.

This is hard to test in dev so we will just have to test in staging, where router is able to send its address to console through sockets.

The new Monitor file is used for storing global state on the backend. Currently it is only storing router address.