### PR TITLE
Event log updates: More dashboard updates

### DIFF
--- a/assets/js/components/events/EventsDashboard.jsx
+++ b/assets/js/components/events/EventsDashboard.jsx
@@ -333,7 +333,7 @@ class EventsDashboard extends Component {
             </Checkbox>
           </span>
           <a
-            href={`data:text/json;charset=utf-8,${encodeURIComponent(JSON.stringify(aggregatedRows, null, 2))}`}
+            href={`data:text/json;charset=utf-8,${encodeURIComponent(JSON.stringify(rows, null, 2))}`}
             download="event-debug.json"
             onClick={() => { analyticsLogger.logEvent("ACTION_EXPORT_DEVICE_EVENTS_LOG", { device_id: this.props.device_id }) }}
           >


### PR DESCRIPTION
Under the assumption that `downlink_ack` will be a standalone type of event (not associated to `downlink_confirmed`, `downlink_unconfimed`, etc.) as well as `uplink_dropped` and `downlink_dropped`, the `Type` on the table will make use of `sub_categories` in the aggregated rows to determine whether to show a more specific type.