### PR TITLE
Event log updates: Update label notification triggers that use events

### DIFF
--- a/lib/console/email.ex
+++ b/lib/console/email.ex
@@ -171,7 +171,7 @@ defmodule Console.Email do
     |> render(:integration_with_devices_updated_notification_email)
   end
 
-  def device_join_otaa_first_time_notification_email(recipients, label_name, details, organization_name, label_id) do
+  def device_join_otaa_first_time_notification_email(recipients, label_name, details, organization_name, label_id, has_hotspot_info) do
     base_email()
     |> to(recipients)
     |> subject("Helium Console: One or more device(s) have joined via OTAA for the first time.")
@@ -180,6 +180,7 @@ defmodule Console.Email do
     |> assign(:organization_name, organization_name)
     |> assign(:details, details)
     |> assign(:label_id, label_id)
+    |> assign(:has_hotspot_info, has_hotspot_info)
     |> render(:device_join_otaa_first_time_notification_email)
   end
 
@@ -195,7 +196,7 @@ defmodule Console.Email do
     |> render(:integration_stops_working_notification_email)
   end
   
-  def device_stops_transmitting_notification_email(recipients, label_name, details, organization_name, label_id) do
+  def device_stops_transmitting_notification_email(recipients, label_name, details, organization_name, label_id, has_hotspot_info) do
     base_email()
     |> to(recipients)
     |> subject("Helium Console: One or more device(s) have stopped transmitting.")
@@ -204,6 +205,7 @@ defmodule Console.Email do
     |> assign(:organization_name, organization_name)
     |> assign(:details, details)
     |> assign(:label_id, label_id)
+    |> assign(:has_hotspot_info, has_hotspot_info)
     |> render(:device_stops_transmitting_notification_email)
   end
 

--- a/lib/console/jobs.ex
+++ b/lib/console/jobs.ex
@@ -91,14 +91,15 @@ defmodule Console.Jobs do
     settings_device_stops_working = LabelNotificationSettings.get_label_notification_settings_by_key("device_stops_transmitting")
     Enum.each(settings_device_stops_working, fn setting -> 
       # value in the setting determines period of time to check if device stopped connecting
-      check_device_stop_transmitting(setting.label_id, Timex.shift(Timex.now, minutes: String.to_integer(setting.value)))
+      buffer = String.to_integer(setting.value)
+      check_device_stop_transmitting(setting.label_id, Timex.shift(Timex.now, minutes: -buffer))
     end)
   end
 
   defp check_device_stop_transmitting(label_id, starting_from) do
     devices = Devices.get_devices_for_label(label_id)
     Enum.each(devices, fn device ->
-      if device.last_connected != nil and device.last_connected < starting_from do
+      if device.last_connected != nil and Timex.compare(device.last_connected, starting_from) == -1 do
         # since we are already iterating by label to begin with, don't include all device's labels to iterate sending notifications by
         event = Events.get_device_last_event(device.id)
         { _, last_connected_time } = Timex.format(device.last_connected, "%m/%d/%y %H:%M:%S UTC", :strftime)

--- a/lib/console_web/controllers/router/device_controller.ex
+++ b/lib/console_web/controllers/router/device_controller.ex
@@ -213,7 +213,10 @@ defmodule ConsoleWeb.Router.DeviceController do
             details = %{
               device_name: event_device.name,
               time: time,
-              # hotspots: Enum.map(event.hotspots, fn h -> %{ name: h.name, rssi: h.rssi, snr: h.snr, spreading: h.spreading, frequency: h.frequency } end)
+              hotspot: case event.data["hotspot"] != nil do
+                false -> nil
+                true -> event.data["hotspot"]
+              end
             }
             device_labels = Enum.map(event_device.labels, fn l -> l.id end)
             LabelNotificationEvents.notify_label_event(device_labels, "device_join_otaa_first_time", details)

--- a/lib/console_web/router.ex
+++ b/lib/console_web/router.ex
@@ -91,7 +91,7 @@ defmodule ConsoleWeb.Router do
   end
 
   scope "/api/router", ConsoleWeb.Router do
-    pipe_through ConsoleWeb.RouterApiPipeline
+    # pipe_through ConsoleWeb.RouterApiPipeline
 
     resources "/devices", DeviceController, only: [:index, :show] do
       post "/event", DeviceController, :add_device_event

--- a/lib/console_web/router.ex
+++ b/lib/console_web/router.ex
@@ -91,7 +91,7 @@ defmodule ConsoleWeb.Router do
   end
 
   scope "/api/router", ConsoleWeb.Router do
-    # pipe_through ConsoleWeb.RouterApiPipeline
+    pipe_through ConsoleWeb.RouterApiPipeline
 
     resources "/devices", DeviceController, only: [:index, :show] do
       post "/event", DeviceController, :add_device_event

--- a/lib/console_web/templates/email/device_join_otaa_first_time_notification_email.html.eex
+++ b/lib/console_web/templates/email/device_join_otaa_first_time_notification_email.html.eex
@@ -187,96 +187,102 @@
 
                                  <!-- content -->
                                  <%= if @num_devices == 1 do %>
-                                  <tr>
-                                    <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                      The device <b><%= List.first(@details)["device_name"] %></b> has joined the Organization <b><%= @organization_name%></b> via OTAA at <b><%= List.first(@details)["time"] %></b>.
-                                    </td>
-                                  </tr>
-                                  <tr>
-                                    <td width="100%" height="10"></td>
-                                 </tr>
-                                  <tr>
-                                    <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                      Details for Hotspot(s) that sent the device packet:
-                                    </td>
-                                  </tr>
-                                  <ul>
-                                  <%= Enum.map(@details, fn(d) -> %>
-                                    <%= Enum.map(d["hotspots"], fn(h) -> %>
-                                       <tr>
+                                    <tr>
                                        <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                          <li>Hotspot <b><%= h["name"] %></b>: RSSI <b><%= h["rssi"] %></b>, SNR <b><%= h["snr"] %></b>, Frequency <b><%= h["frequency"] %></b>, Spreading <b><%= h["spreading"] %></b></li>
+                                       The device <b><%= List.first(@details)["device_name"] %></b> has joined the Organization <b><%= @organization_name%></b> via OTAA at <b><%= List.first(@details)["time"] %></b>.
                                        </td>
+                                    </tr>
+                                    <tr>
+                                       <td width="100%" height="10"></td>
+                                    </tr>
+                                    <%= if @has_hotspot_info do %>
+                                       <tr>
+                                          <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
+                                          Details for Hotspot(s) that sent the device packet:
+                                          </td>
                                        </tr>
-                                    <% end) %>
-                                  <% end) %>
-                                  </ul>
+                                       <ul>
+                                       <%= Enum.map(@details, fn(d) -> %>
+                                          <%= if d["hotspot"] do %>
+                                             <tr>
+                                             <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
+                                                <li>Hotspot <b><%= d["hotspot"]["name"] %></b>: RSSI <b><%= d["hotspot"]["rssi"] %></b>, SNR <b><%= d["hotspot"]["snr"] %></b>, Frequency <b><%= d["hotspot"]["frequency"] %></b>, Spreading <b><%= d["hotspot"]["spreading"] %></b></li>
+                                             </td>
+                                             </tr>
+                                          <% end %>
+                                       <% end) %>
+                                       </ul>
+                                    <% end %>
                                  <% end %>
                                  
                                  <%= if @num_devices > 1 && @num_devices <= 5 do %>
-                                  <tr>
-                                    <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                      The devices:
-                                    </td>
-                                  </tr>
-                                  <%= Enum.map(@details, fn(d) -> %>
-                                  <tr>
-                                    <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                      <li><b><%= d["device_name"] %></b></li>
-                                    </td>
-                                  </tr>
-                                  <% end) %>
-                                  <tr>
-                                    <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                      have joined the Organization <b><%= @organization_name%></b> via OTAA at <b><%= List.first(@details)["time"] %></b>.
-                                    </td>
-                                  </tr>
-                                  <tr>
-                                    <td width="100%" height="10"></td>
-                                 </tr>
-                                  <tr>
-                                    <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                      Hotspot details that sent device packet include:
-                                    </td>
-                                  </tr>
-                                  <ul>
-                                  <%= Enum.map(@details, fn(d) -> %>
-                                    <%= Enum.map(d["hotspots"], fn(h) -> %>
-                                       <tr>
+                                    <tr>
                                        <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                          <li>RSSI <b><%= h["rssi"] %></b>, SNR <b><%= h["snr"] %></b>, Frequency <b><%= h["frequency"] %></b>, Spreading <b><%= h["spreading"] %></b></li>
+                                       The devices:
                                        </td>
-                                       </tr>
+                                    </tr>
+                                    <%= Enum.map(@details, fn(d) -> %>
+                                    <tr>
+                                       <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
+                                       <li><b><%= d["device_name"] %></b></li>
+                                       </td>
+                                    </tr>
                                     <% end) %>
-                                  <% end) %>
-                                  </ul>
+                                    <tr>
+                                       <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
+                                       have joined the Organization <b><%= @organization_name%></b> via OTAA at <b><%= List.first(@details)["time"] %></b>.
+                                       </td>
+                                    </tr>
+                                    <tr>
+                                       <td width="100%" height="10"></td>
+                                    </tr>
+                                    <%= if @has_hotspot_info do %>
+                                       <tr>
+                                          <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
+                                          Hotspot details that sent device packet include:
+                                          </td>
+                                       </tr>
+                                       <ul>
+                                       <%= Enum.map(@details, fn(d) -> %>
+                                          <%= if d["hotspot"] do %>
+                                             <tr>
+                                             <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
+                                                <li>Hotspot <b><%= d["hotspot"]["name"] %></b>: RSSI <b><%= d["hotspot"]["rssi"] %></b>, SNR <b><%= d["hotspot"]["snr"] %></b>, Frequency <b><%= d["hotspot"]["frequency"] %></b>, Spreading <b><%= d["hotspot"]["spreading"] %></b></li>
+                                             </td>
+                                             </tr>
+                                          <% end %>
+                                       <% end) %>
+                                       </ul>
+                                    <% end %>
                                  <% end %>
 
                                  <%= if @num_devices > 5 do %>
-                                  <tr>
-                                    <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                      More than 5 devices that belong to the Organization <b><%= @organization_name %></b> joined via OTAA at <b><%= List.first(@details)["time"] %></b>.
-                                    </td>
-                                  </tr>
-                                  <tr>
-                                    <td width="100%" height="10"></td>
-                                 </tr>
-                                  <tr>
-                                    <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                      Hotspot details that sent device packet include:
-                                    </td>
-                                  </tr>
-                                  <ul>
-                                  <%= Enum.map(@details, fn(d) -> %>
-                                    <%= Enum.map(d["hotspots"], fn(h) -> %>
-                                       <tr>
+                                    <tr>
                                        <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                          <li>RSSI <b><%= h["rssi"] %></b>, SNR <b><%= h["snr"] %></b>, Frequency <b><%= h["frequency"] %></b>, Spreading <b><%= h["spreading"] %></b></li>
+                                       More than 5 devices that belong to the Organization <b><%= @organization_name %></b> joined via OTAA at <b><%= List.first(@details)["time"] %></b>.
                                        </td>
+                                    </tr>
+                                    <tr>
+                                       <td width="100%" height="10"></td>
+                                    </tr>
+                                    <%= if @has_hotspot_info do %>
+                                       <tr>
+                                          <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
+                                          Hotspot details that sent device packet include:
+                                          </td>
                                        </tr>
-                                    <% end) %>
-                                  <% end) %>
-                                  </ul>
+                                       <ul>
+                                       <%= Enum.map(@details, fn(d) -> %>
+                                          <%= if d["hotspot"] do %>
+                                             <tr>
+                                             <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
+                                                <li>Hotspot <b><%= d["hotspot"]["name"] %></b>: RSSI <b><%= d["hotspot"]["rssi"] %></b>, SNR <b><%= d["hotspot"]["snr"] %></b>, Frequency <b><%= d["hotspot"]["frequency"] %></b>, Spreading <b><%= d["hotspot"]["spreading"] %></b></li>
+                                             </td>
+                                             </tr>
+                                          <% end %>
+                                       <% end) %>
+                                       </ul>
+                                    <% end %>
                                  <% end %>
                                  <!-- end of content -->
                                  <tr>

--- a/lib/console_web/templates/email/device_join_otaa_first_time_notification_email.text.eex
+++ b/lib/console_web/templates/email/device_join_otaa_first_time_notification_email.text.eex
@@ -1,13 +1,13 @@
 <%= @label_name %> Notification
 
 <%= if @num_devices == 1 do %>
-    The device <%= List.first(@details)["device_name"] %> has joined the Organization <%= @organization_name%> via OTAA at <%= List.first(@details)["time"] %>.
+  The device <%= List.first(@details)["device_name"] %> has joined the Organization <%= @organization_name%> via OTAA at <%= List.first(@details)["time"] %>.
+  <%= if @has_hotspot_info do %>
     Details for Hotspot(s) that sent the device packet:
-  <%= Enum.map(@details, fn(d) -> %>
-    <%= Enum.map(d["hotspots"], fn(h) -> %>
-      Hotspot <%= h["name"] %>: RSSI <%= h["rssi"] %>, SNR <%= h["snr"] %>, Frequency <%= h["frequency"] %>, Spreading <%= h["spreading"] %>
+    <%= Enum.map(@details, fn(d) -> %>
+      Hotspot <%= d["hotspot"]["name"] %>: RSSI <%= d["hotspot"]["rssi"] %>, SNR <%= d["hotspot"]["snr"] %>, Frequency <%= d["hotspot"]["frequency"] %>, Spreading <%= d["hotspot"]["spreading"] %>
     <% end) %>
-  <% end) %>
+  <% end %>
 <% end %>
 <%= if @num_devices > 1 && @num_devices <= 5 do %>
   The devices:
@@ -15,19 +15,19 @@
     <%= d["device_name"] %>
   <% end) %>
   have joined the Organization <%= @organization_name%> via OTAA at <%= List.first(@details)["time"] %>.
-  Hotspot details that sent device packet include:
-  <%= Enum.map(@details, fn(d) -> %>
-    <%= Enum.map(d["hotspots"], fn(h) -> %>
-      RSSI <%= h["rssi"] %>, SNR <%= h["snr"] %>, Frequency <%= h["frequency"] %>, Spreading <%= h["spreading"] %>
+  <%= if @has_hotspot_info do %>
+    Hotspot details that sent device packet include:
+    <%= Enum.map(@details, fn(d) -> %>
+      RSSI <%= d["hotspot"]["rssi"] %>, SNR <%= d["hotspot"]["snr"] %>, Frequency <%= d["hotspot"]["frequency"] %>, Spreading <%= d["hotspot"]["spreading"] %>
     <% end) %>
-  <% end) %>
+  <% end %>
 <% end %>
 <%= if @num_devices > 5 do %>
   More than 5 devices that belong to the Organization <%= @organization_name %> joined via OTAA at <%= List.first(@details)["time"] %>.
-  Hotspot details that sent device packet include:
-  <%= Enum.map(@details, fn(d) -> %>
-    <%= Enum.map(d["hotspots"], fn(h) -> %>
-      RSSI <%= h["rssi"] %>, SNR <%= h["snr"] %>, Frequency <%= h["frequency"] %>, Spreading <%= h["spreading"] %>
+  <%= if @has_hotspot_info do %>
+    Hotspot details that sent device packet include:
+    <%= Enum.map(@details, fn(d) -> %>
+        RSSI <%= d["hotspot"]["rssi"] %>, SNR <%= d["hotspot"]["snr"] %>, Frequency <%= d["hotspot"]["frequency"] %>, Spreading <%= d["hotspot"]["spreading"] %>
     <% end) %>
-  <% end) %>
+  <% end %>
 <% end %>

--- a/lib/console_web/templates/email/device_stops_transmitting_notification_email.html.eex
+++ b/lib/console_web/templates/email/device_stops_transmitting_notification_email.html.eex
@@ -195,22 +195,24 @@
                                   <tr>
                                     <td width="100%" height="10"></td>
                                  </tr>
-                                  <tr>
-                                    <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                      Details for Hotspot(s) that sent last received device packet:
-                                    </td>
-                                  </tr>
-                                  <ul>
-                                  <%= Enum.map(@details, fn(d) -> %>
-                                    <%= Enum.map(d["hotspots"], fn(h) -> %>
+                                 <%= if @has_hotspot_info do %>
+                                    <tr>
+                                       <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
+                                       Details for Hotspot that sent last received device packet:
+                                       </td>
+                                    </tr>
+                                    <ul>
+                                    <%= Enum.map(@details, fn(d) -> %>
                                        <tr>
                                        <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                          <li>Hotspot <b><%= h["name"] %></b>: RSSI <b><%= h["rssi"] %></b>, SNR <b><%= h["snr"] %></b>, Frequency <b><%= h["frequency"] %></b>, Spreading <b><%= h["spreading"] %></b></li>
+                                          <%= if d["hotspot"] do %>
+                                             <li>Hotspot <b><%= d["hotspot"]["name"] %></b>: RSSI <b><%= d["hotspot"]["rssi"] %></b>, SNR <b><%= d["hotspot"]["snr"] %></b>, Frequency <b><%= d["hotspot"]["frequency"] %></b>, Spreading <b><%= d["hotspot"]["spreading"] %></b></li>
+                                          <% end %>
                                        </td>
                                        </tr>
                                     <% end) %>
-                                  <% end) %>
-                                  </ul>
+                                    </ul>
+                                    <% end %>
                                  <% end %>
                                  
                                  <%= if @num_devices > 1 && @num_devices <= 5 do %>
@@ -234,22 +236,24 @@
                                   <tr>
                                     <td width="100%" height="10"></td>
                                  </tr>
-                                  <tr>
-                                    <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                      Hotspot details that sent last received device packet include:
-                                    </td>
-                                  </tr>
-                                  <ul>
-                                  <%= Enum.map(@details, fn(d) -> %>
-                                    <%= Enum.map(d["hotspots"], fn(h) -> %>
+                                 <%= if @has_hotspot_info do %>
+                                    <tr>
+                                       <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
+                                       Hotspot details that sent last received device packet include:
+                                       </td>
+                                    </tr>
+                                    <ul>
+                                    <%= Enum.map(@details, fn(d) -> %>
                                        <tr>
                                        <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                          <li>RSSI <b><%= h["rssi"] %></b>, SNR <b><%= h["snr"] %></b>, Frequency <b><%= h["frequency"] %></b>, Spreading <b><%= h["spreading"] %></b></li>
+                                          <%= if d["hotspot"] do %>
+                                             <li>Hotspot <b><%= d["hotspot"]["name"] %></b>: RSSI <b><%= d["hotspot"]["rssi"] %></b>, SNR <b><%= d["hotspot"]["snr"] %></b>, Frequency <b><%= d["hotspot"]["frequency"] %></b>, Spreading <b><%= d["hotspot"]["spreading"] %></b></li>
+                                          <% end %>
                                        </td>
                                        </tr>
                                     <% end) %>
-                                  <% end) %>
-                                  </ul>
+                                    </ul>
+                                    <% end %>
                                  <% end %>
 
                                  <%= if @num_devices > 5 do %>

--- a/lib/console_web/templates/email/device_stops_transmitting_notification_email.html.eex
+++ b/lib/console_web/templates/email/device_stops_transmitting_notification_email.html.eex
@@ -203,13 +203,13 @@
                                     </tr>
                                     <ul>
                                     <%= Enum.map(@details, fn(d) -> %>
-                                       <tr>
-                                       <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                          <%= if d["hotspot"] do %>
+                                       <%= if d["hotspot"] do %>
+                                          <tr>
+                                          <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
                                              <li>Hotspot <b><%= d["hotspot"]["name"] %></b>: RSSI <b><%= d["hotspot"]["rssi"] %></b>, SNR <b><%= d["hotspot"]["snr"] %></b>, Frequency <b><%= d["hotspot"]["frequency"] %></b>, Spreading <b><%= d["hotspot"]["spreading"] %></b></li>
-                                          <% end %>
-                                       </td>
-                                       </tr>
+                                          </td>
+                                          </tr>
+                                       <% end %>
                                     <% end) %>
                                     </ul>
                                     <% end %>
@@ -244,13 +244,13 @@
                                     </tr>
                                     <ul>
                                     <%= Enum.map(@details, fn(d) -> %>
-                                       <tr>
-                                       <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
-                                          <%= if d["hotspot"] do %>
+                                       <%= if d["hotspot"] do %>
+                                          <tr>
+                                          <td style="font-family:avenir, apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,sans-serif; font-size: 18px; color: #333333; text-align:left;line-height: 22px;padding: 0 60px" st-title="rightimage-title">
                                              <li>Hotspot <b><%= d["hotspot"]["name"] %></b>: RSSI <b><%= d["hotspot"]["rssi"] %></b>, SNR <b><%= d["hotspot"]["snr"] %></b>, Frequency <b><%= d["hotspot"]["frequency"] %></b>, Spreading <b><%= d["hotspot"]["spreading"] %></b></li>
-                                          <% end %>
-                                       </td>
-                                       </tr>
+                                          </td>
+                                          </tr>
+                                       <% end %>
                                     <% end) %>
                                     </ul>
                                     <% end %>

--- a/lib/console_web/templates/email/device_stops_transmitting_notification_email.text.eex
+++ b/lib/console_web/templates/email/device_stops_transmitting_notification_email.text.eex
@@ -1,13 +1,15 @@
 <%= @label_name %> Notification
 
 <%= if @num_devices == 1 do %>
-    The device <%= List.first(@details)["device_name"] %> that belongs to the Organization <%= @organization_name%> stopped transmitting on <%= List.first(@details)["time"] %>.
+  The device <%= List.first(@details)["device_name"] %> that belongs to the Organization <%= @organization_name%> stopped transmitting on <%= List.first(@details)["time"] %>.
+  <%= if @has_hotspot_info do %>
     Details for Hotspot(s) that sent the last received device packet:
-  <%= Enum.map(@details, fn(d) -> %>
-    <%= Enum.map(d["hotspots"], fn(h) -> %>
-      Hotspot <%= h["name"] %>: RSSI <%= h["rssi"] %>, SNR <%= h["snr"] %>, Frequency <%= h["frequency"] %>, Spreading <%= h["spreading"] %>
+    <%= Enum.map(@details, fn(d) -> %>
+      <%= if d["hotspot"] do %>
+        Hotspot <%= d["hotspot"]["name"] %>: RSSI <%= d["hotspot"]["rssi"] %>, SNR <%= d["hotspot"]["snr"] %>, Frequency <%= d["hotspot"]["frequency"] %>, Spreading <%= d["hotspot"]["spreading"] %>
+      <% end %>
     <% end) %>
-  <% end) %>
+  <% end %>
 <% end %>
 <%= if @num_devices > 1 && @num_devices <= 5 do %>
   The devices:
@@ -15,12 +17,14 @@
     <%= d["device_name"] %>
   <% end) %>
   that belong to the Organization <%= @organization_name%> stopped transmitting on <%= List.first(@details)["time"] %>.
-  Hotspot details that sent last received device packet include:
-  <%= Enum.map(@details, fn(d) -> %>
-    <%= Enum.map(d["hotspots"], fn(h) -> %>
-      RSSI <%= h["rssi"] %>, SNR <%= h["snr"] %>, Frequency <%= h["frequency"] %>, Spreading <%= h["spreading"] %>
+  <%= if @has_hotspot_info do %>
+    Hotspot details that sent last received device packet include:
+    <%= Enum.map(@details, fn(d) -> %>
+      <%= if d["hotspot"] do %>
+        Hotspot <%= d["hotspot"]["name"] %>: RSSI <%= d["hotspot"]["rssi"] %>, SNR <%= d["hotspot"]["snr"] %>, Frequency <%= d["hotspot"]["frequency"] %>, Spreading <%= d["hotspot"]["spreading"] %>
+      <% end %>
     <% end) %>
-  <% end) %>
+  <% end %>
 <% end %>
 <%= if @num_devices > 5 do %>
   More than 5 devices that belong to the Organization <%= @organization_name %> stopped transmitting on <%= List.first(@details)["time"] %>.


### PR DESCRIPTION
Since 2 label notification types include event information, had to update this since `hotspots` no longer come in aggregated. Trigger and html/text templates updated. Additionally fixed a small bug w/ `device_join_otaa_first_time` with time comparison.