### PR TITLE
Event log updates: Handle time in MS

### DIFF
--- a/assets/js/components/common/PacketGraph.jsx
+++ b/assets/js/components/common/PacketGraph.jsx
@@ -102,12 +102,12 @@ class PacketGraph extends Component {
 
     events.forEach(event => {
       const currentTime = Date.now() / 1000
-      const eventTime =  event.reported_at
+      const eventTime =  parseInt(event.reported_at) / 1000
       const timeDiff = currentTime - eventTime
       const integrations = event.integrations
       const hotspots = event.hotspots
 
-      if ( timeDiff < 300 ) {
+      if (timeDiff < 300) {
         if (integrations[0] && integrations[0].status == 'success') {
           success.push({
             x: timeDiff,

--- a/assets/js/components/events/EventsDashboard.jsx
+++ b/assets/js/components/events/EventsDashboard.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { formatUnixDatetime, getDiffInSeconds } from '../../util/time'
+import { formatDatetime, getDiffInSeconds } from '../../util/time'
 import analyticsLogger from '../../util/analyticsLogger';
 import groupBy from 'lodash/groupBy';
 import sortBy from 'lodash/sortBy';
@@ -129,7 +129,7 @@ class EventsDashboard extends Component {
         { title: 'Hotspot Name', dataIndex: 'name' },
         { title: 'Frequency', dataIndex: 'frequency', render: data => <span>{(Math.round(data * 100) / 100).toFixed(2)}</span> },
         { title: 'Spreading', dataIndex: 'spreading' },
-        { title: 'Time', dataIndex: 'time', render: data => <Text style={{textAlign:'left'}}>{formatUnixDatetime(data)}</Text>}
+        { title: 'Time', dataIndex: 'time', render: data => <Text style={{textAlign:'left'}}>{formatDatetime(data)}</Text>}
       ]
     } else {
       hotspotColumns = [
@@ -138,7 +138,7 @@ class EventsDashboard extends Component {
         { title: 'SNR', dataIndex: 'snr', render: data => <span>{(Math.round(data * 100) / 100).toFixed(2)}</span> },
         { title: 'Frequency', dataIndex: 'frequency', render: data => <span>{(Math.round(data * 100) / 100).toFixed(2)}</span> },
         { title: 'Spreading', dataIndex: 'spreading' },
-        { title: 'Time', dataIndex: 'time', render: data => <Text style={{textAlign:'left'}}>{formatUnixDatetime(data)}</Text>}
+        { title: 'Time', dataIndex: 'time', render: data => <Text style={{textAlign:'left'}}>{formatDatetime(data)}</Text>}
       ]
     }
 
@@ -296,7 +296,7 @@ class EventsDashboard extends Component {
         title: 'Time',
         dataIndex: 'reported_at',
         align: 'left',
-        render: data => <Text style={{textAlign:'left'}}>{formatUnixDatetime(data)}</Text>
+        render: data => <Text style={{textAlign:'left'}}>{formatDatetime(data)}</Text>
       }
     ]
 

--- a/assets/js/util/time.js
+++ b/assets/js/util/time.js
@@ -1,11 +1,7 @@
 import moment from 'moment'
 
-export const formatDatetime = (datetime, format = 'LLL') => (
-  moment.utc(datetime).utcOffset(moment().utcOffset()).format(format)
-)
-
-export const formatUnixDatetime = (datetime, format = 'll') => (
-  `${moment.unix(datetime).utcOffset(moment().utcOffset()).format(format)} ${moment.unix(datetime).utcOffset(moment().utcOffset()).format("LTS")}`
+export const formatDatetime = (datetime, format = 'll') => (
+  `${moment(parseInt(datetime)).utcOffset(moment().utcOffset()).format(format)} ${moment(parseInt(datetime)).utcOffset(moment().utcOffset()).format("h:mm:ss.SSS A")}`
 )
 
 export const formatDatetimeAgo = (datetime) => (
@@ -13,5 +9,5 @@ export const formatDatetimeAgo = (datetime) => (
 )
 
 export const getDiffInSeconds = (datetime) => (
-  moment().diff(moment.unix(datetime), 'seconds')
+  moment().diff(moment(datetime), 'seconds')
 )

--- a/lib/console/events/events.ex
+++ b/lib/console/events/events.ex
@@ -24,7 +24,7 @@ defmodule Console.Events do
   def create_event(attrs \\ %{}) do
     reported_at_naive =
       attrs["reported_at"]
-      |> DateTime.from_unix!()
+      |> DateTime.from_unix!(:millisecond)
       |> DateTime.to_naive()
     reported_at = Integer.to_string(attrs["reported_at"])
 

--- a/test/console_web/controllers/router/router_device_controller_test.exs
+++ b/test/console_web/controllers/router/router_device_controller_test.exs
@@ -83,7 +83,7 @@ defmodule ConsoleWeb.RouterDeviceControllerTest do
       organization = insert(:organization)
       device_0 = insert(:device, %{ organization_id: organization.id })
       channel_0 = insert(:channel, %{ organization_id: organization.id })
-      timestamp = NaiveDateTime.utc_now() |> NaiveDateTime.diff(~N[1970-01-01 00:00:00])
+      timestamp = NaiveDateTime.utc_now() |> NaiveDateTime.diff(~N[1970-01-01 00:00:00], :millisecond)
 
       resp_conn = build_conn()
         |> put_req_header("authorization", "Bearer " <> jwt)


### PR DESCRIPTION
This PR accounts for the fact that router will be sending in the time in milliseconds.

![image](https://user-images.githubusercontent.com/51131939/110675703-0c7d3680-8188-11eb-9a75-a9e150754813.png)


tests passing
```
.................................................

Finished in 1.2 seconds
49 tests, 0 failures
```