### PR TITLE
Event log updates: Remaining label notification triggers

### DIFF
--- a/lib/console_web/controllers/router/device_controller.ex
+++ b/lib/console_web/controllers/router/device_controller.ex
@@ -215,7 +215,7 @@ defmodule ConsoleWeb.Router.DeviceController do
 
           case event.category do
             "uplink" ->
-              if event.data["integration"]["id"] != "no_channel" do
+              if event.data["integration"] != nil and event.data["integration"]["id"] != "no_channel" do
                 event_integration = Channels.get_channel(event.data["integration"]["id"]) |> Repo.preload([:labels])
                 labels = Enum.map(event_integration.labels, fn l -> l.id end)
 


### PR DESCRIPTION
Fix for remaining label notification triggers that involved events

```

...............................................

Finished in 1.2 seconds
49 tests, 0 failures
```