### PR TITLE
Allow downlink panel to show queue from router

### DIFF
--- a/assets/js/actions/device.js
+++ b/assets/js/actions/device.js
@@ -201,15 +201,6 @@ const sanitizeParams = (params) => {
   return params
 }
 
-export const sendClearDownlinkQueue = (payload) => {
-  return (dispatch) => {
-    rest.post(
-      '/api/clear_downlink_queue',
-      payload
-    );
-  }
-}
-
 export const getAllEvents = (deviceId) => {
   return (dispatch) => {
     return rest.get(`/api/devices/${deviceId}/events`)

--- a/assets/js/actions/downlink.js
+++ b/assets/js/actions/downlink.js
@@ -1,0 +1,16 @@
+import * as rest from '../util/rest';
+
+export const sendClearDownlinkQueue = (payload) => {
+  return (dispatch) => {
+    rest.post(
+      '/api/clear_downlink_queue',
+      payload
+    );
+  }
+}
+
+export const fetchDownlinkQueue = (id, type) => {
+  return (dispatch) => {
+    rest.get(`/api/downlink_queue?type=${type}&id=${id}`)
+  }
+}

--- a/assets/js/components/common/Downlink.jsx
+++ b/assets/js/components/common/Downlink.jsx
@@ -1,88 +1,143 @@
-import React, { useState } from 'react';
+import React, { Component } from 'react';
 import { Card, Typography, Input, InputNumber, Row, Col, Radio, Checkbox, Tooltip, Button as RegularButton } from 'antd';
 import DownlinkImage from '../../../img/downlink.svg';
 import { ClearOutlined } from '@ant-design/icons';
 
 const { Title, Text } = Typography;
 const { Group, Button } = Radio;
+const REFRESH_TIME_TO_WAIT = 600000
 
-const Downlink = ({src, onSend, onClear}) => {
-  const [port, setPort] = useState(1);
-  const [confirm, setConfirm] = useState(true);
-  const [payloadType, setPayloadType] = useState('bytes');
-  const [payload, setPayload] = useState('');
-  const [position, setPosition] = useState("last");
+class Downlink extends Component {
+  state = {
+    port: 1,
+    confirm: true,
+    payloadType: 'bytes',
+    payload: '',
+    position: 'last',
+    showRefresh: false
+  }
 
-  return (
-    <React.Fragment>
-      <div style={{position: 'relative'}}>
-        <Card style={{marginRight: 20, marginLeft: 20, marginTop: -25}}>
-          <Title style={{fontSize: 22}}>Add Downlink Payload</Title>
+  componentDidMount() {
+    const { id, src, fetchDownlinkQueue, socket } = this.props
+    fetchDownlinkQueue()
+    this.showRefreshTimer = setTimeout(() => this.setState({ showRefresh: true }), REFRESH_TIME_TO_WAIT)
 
-          <Row gutter={[16, 16]}>
-            <Col span={12}>
-              <Text style={{ display: "block", marginBottom: 4 }}>Scheduling</Text>
-              <Group value={position} buttonStyle="solid" onChange={el => setPosition(el.target.value)}>
-                <Button value="first">First</Button>
-                <Button value="last">Last</Button>
-              </Group>
-            </Col>
-            <Col span={12}>
-              <Text style={{ display: "block", marginBottom: 4 }}>FPort</Text>
-              <InputNumber style={{ width: '100%' }}defaultValue={1} min={1} max={222} onChange={setPort}/>
-            </Col>
-          </Row>
+    if (src === "DeviceShow") {
+      this.channel = socket.channel("graphql:device_show_downlink", {})
+      this.channel.join()
+      this.channel.on(`graphql:device_show_downlink:${id}:update_queue`, (message) => {
+        // render the queue items
+        console.log(message)
+      })
+    }
+    if (this.props.src === "LabelShow") {
+      this.channel = socket.channel("graphql:label_show_downlink", {})
+      this.channel.join()
+      this.channel.on(`graphql:label_show_downlink:${id}:update_queue`, (message) => {
+        // render the queue items
+        console.log(message)
+      })
+    }
+  }
 
-          <div style={{ marginTop: 15 }}>
-            <Text style={{ display: "block", marginBottom: 4 }}>Payload</Text>
-            <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
-              <Input placeholder="Enter Payload" onChange={(e) => setPayload(e.target.value)} style={{ marginRight: 16 }}/>
+  componentWillUnmount() {
+    this.channel.leave()
+    clearTimeout(this.showRefreshTimer)
+  }
 
-              <Tooltip title='Select bytes to send a Base64 encoded payload, or fields to have the payload Base64 encoded for you.' placement='left'>
-                <Group value={payloadType} onChange={(el) => setPayloadType(el.target.value)} buttonStyle="solid" style={{ display: 'flex', flexDirection: 'row' }}>
-                  <Button value="bytes">Bytes</Button>
-                  <Button value="fields">Fields</Button>
+  refreshQueue = () => {
+    this.props.fetchDownlinkQueue()
+    this.setState({ showRefresh: false })
+    this.showRefreshTimer = setTimeout(() => this.setState({ showRefresh: true }), REFRESH_TIME_TO_WAIT)
+  }
+
+  render() {
+    const { src, onSend, onClear } = this.props
+    const { position, port, confirm, payload, payloadType } = this.state
+
+    return (
+      <React.Fragment>
+        <div style={{position: 'relative'}}>
+          <Card style={{marginRight: 20, marginLeft: 20, marginTop: -25}}>
+            <Title style={{fontSize: 22}}>Add Downlink Payload</Title>
+
+            <Row gutter={[16, 16]}>
+              <Col span={12}>
+                <Text style={{ display: "block", marginBottom: 4 }}>Scheduling</Text>
+                <Group value={position} buttonStyle="solid" onChange={el => this.setState({ position: el.target.value })}>
+                  <Button value="first">First</Button>
+                  <Button value="last">Last</Button>
                 </Group>
-              </Tooltip>
+              </Col>
+              <Col span={12}>
+                <Text style={{ display: "block", marginBottom: 4 }}>FPort</Text>
+                <InputNumber style={{ width: '100%' }} defaultValue={1} min={1} max={222} onChange={port => this.setState({ port })}/>
+              </Col>
+            </Row>
+
+            <div style={{ marginTop: 15 }}>
+              <Text style={{ display: "block", marginBottom: 4 }}>Payload</Text>
+              <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+                <Input placeholder="Enter Payload" onChange={(e) => this.setState({ payload: e.target.value })} style={{ marginRight: 16 }}/>
+
+                <Tooltip title='Select bytes to send a Base64 encoded payload, or fields to have the payload Base64 encoded for you.' placement='left'>
+                  <Group value={payloadType} onChange={(el) => this.setState({ payloadType: el.target.value})} buttonStyle="solid" style={{ display: 'flex', flexDirection: 'row' }}>
+                    <Button value="bytes">Bytes</Button>
+                    <Button value="fields">Fields</Button>
+                  </Group>
+                </Tooltip>
+              </div>
+            </div>
+
+            <div style={{ marginTop: 15 }}>
+              <Checkbox
+                checked={confirm}
+                onChange={(e) => this.setState({ confirm: e.target.checked })}
+                style={{ marginRight: 8}}
+              />
+              <Text>I'd like confirmation of response</Text>
+            </div>
+          </Card>
+          <div style={{position: 'absolute', bottom: -16, right: 40, backgroundColor: '#40A9FF', borderRadius: 9999, width: 40, height: 40}}>
+            <div style={{position: 'relative', width: '100%', height: '100%', cursor: 'pointer'}}
+              onClick={() => {
+                const message = payloadType === 'fields' ? Buffer.from(payload).toString('base64') : payload;
+                onSend(message, confirm, port, position);
+              }}
+            >
+              <img
+                src={DownlinkImage}
+                style={{height: 18, width: 24, position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50% , -50%)'}}
+              />
             </div>
           </div>
-
-          <div style={{ marginTop: 15 }}>
-            <Checkbox
-              checked={confirm}
-              onChange={(e) => setConfirm(e.target.checked)}
-              style={{ marginRight: 8}}
-            />
-            <Text>I'd like confirmation of response</Text>
-          </div>
-        </Card>
-        <div style={{position: 'absolute', bottom: -16, right: 40, backgroundColor: '#40A9FF', borderRadius: 9999, width: 40, height: 40}}>
-          <div style={{position: 'relative', width: '100%', height: '100%', cursor: 'pointer'}}
-            onClick={() => {
-              const message = payloadType === 'fields' ? Buffer.from(payload).toString('base64') : payload;
-              onSend(message, confirm, port, position);
-            }}
-          >
-            <img
-              src={DownlinkImage}
-              style={{height: 18, width: 24, position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50% , -50%)'}}
-            />
-          </div>
         </div>
-      </div>
-      <div style={{marginRight: 20, marginLeft: 20, marginTop: 15}}>
-      <RegularButton
-          size="large"
-          type="primary"
-          icon={<ClearOutlined />}
-          onClick={() => {onClear()}}
-          style={{ borderRadius: 4 }}
-        >
-          {src === "DeviceShow" ? "Clear Queue for Device" : "Clear Queue for All Label's Devices"}
-        </RegularButton>
-      </div>
-    </React.Fragment>
-  )
+        <div style={{ margin: 20 }}>
+          {
+            this.state.showRefresh && (
+              <RegularButton
+                type="primary"
+                onClick={this.refreshQueue}
+              >
+                Refetch Queue
+              </RegularButton>
+            )
+          }
+        </div>
+        <div style={{marginRight: 20, marginLeft: 20, marginTop: 15}}>
+          <RegularButton
+            size="large"
+            type="primary"
+            icon={<ClearOutlined />}
+            onClick={() => {onClear()}}
+            style={{ borderRadius: 4 }}
+          >
+            {src === "DeviceShow" ? "Clear Queue for Device" : "Clear Queue for All Label's Devices"}
+          </RegularButton>
+        </div>
+      </React.Fragment>
+    )
+  }
 }
 
 export default Downlink

--- a/assets/js/components/devices/DeviceShow.jsx
+++ b/assets/js/components/devices/DeviceShow.jsx
@@ -17,7 +17,8 @@ import DevicesAddLabelModal from './DevicesAddLabelModal'
 import DeviceCredentials from './DeviceCredentials'
 import DeviceShowStats from './DeviceShowStats'
 import DeleteDeviceModal from './DeleteDeviceModal';
-import { updateDevice, toggleDeviceDebug, sendClearDownlinkQueue } from '../../actions/device'
+import { updateDevice, toggleDeviceDebug } from '../../actions/device'
+import { sendClearDownlinkQueue, fetchDownlinkQueue } from '../../actions/downlink'
 import { sendDownlinkMessage } from '../../actions/channel'
 import { DEVICE_SHOW } from '../../graphql/devices'
 import analyticsLogger from '../../util/analyticsLogger'
@@ -508,6 +509,8 @@ class DeviceShow extends Component {
               >
                 <Downlink
                   src="DeviceShow"
+                  id={device.id}
+                  socket={this.props.socket}
                   onSend={(payload, confirm, port, position) => {
                     analyticsLogger.logEvent("ACTION_DOWNLINK_SEND", { "channels": channels.map(c => c.id) });
                     this.props.sendDownlinkMessage(
@@ -523,6 +526,7 @@ class DeviceShow extends Component {
                     analyticsLogger.logEvent("ACTION_CLEAR_DOWNLINK_QUEUE", { "devices": [device.id] });
                     this.props.sendClearDownlinkQueue({ device_id: device.id });
                   }}
+                  fetchDownlinkQueue={() => this.props.fetchDownlinkQueue(device.id, "device")}
                 />
               </Sidebar>
             }
@@ -539,7 +543,7 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ updateDevice, toggleDeviceDebug, sendClearDownlinkQueue, sendDownlinkMessage }, dispatch)
+  return bindActionCreators({ updateDevice, toggleDeviceDebug, sendClearDownlinkQueue, sendDownlinkMessage, fetchDownlinkQueue }, dispatch)
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(

--- a/assets/js/components/labels/LabelShow.jsx
+++ b/assets/js/components/labels/LabelShow.jsx
@@ -19,7 +19,7 @@ import DownlinkImage from '../../../img/downlink.svg'
 import { debugSidebarBackgroundColor } from '../../util/colors'
 import { updateLabel, addDevicesToLabels, toggleLabelDebug, updateLabelNotificationSettings, updateLabelNotificationWebhooks } from '../../actions/label'
 import { sendDownlinkMessage } from '../../actions/channel'
-import { sendClearDownlinkQueue } from '../../actions/device'
+import { sendClearDownlinkQueue, fetchDownlinkQueue } from '../../actions/downlink'
 import { LABEL_SHOW } from '../../graphql/labels'
 import analyticsLogger from '../../util/analyticsLogger'
 import withGql from '../../graphql/withGql'
@@ -266,6 +266,8 @@ class LabelShow extends Component {
             >
               <Downlink
                 src="LabelShow"
+                socket={this.props.socket}
+                id={label.id}
                 onSend={(payload, confirm, port, position) => {
                   analyticsLogger.logEvent("ACTION_DOWNLINK_SEND", { "channels": label.channels.map(c => c.id) });
                   this.props.sendDownlinkMessage(
@@ -281,6 +283,7 @@ class LabelShow extends Component {
                   analyticsLogger.logEvent("ACTION_CLEAR_DOWNLINK_QUEUE", { "devices": label.devices.map(device => device.id) });
                   this.props.sendClearDownlinkQueue({ label_id: label.id });
                 }}
+                fetchDownlinkQueue={() => this.props.fetchDownlinkQueue(label.id, "label")}
               />
             </Sidebar>
           }
@@ -297,7 +300,7 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ updateLabel, addDevicesToLabels, toggleLabelDebug, sendDownlinkMessage, sendClearDownlinkQueue, updateLabelNotificationSettings, updateLabelNotificationWebhooks }, dispatch)
+  return bindActionCreators({ updateLabel, addDevicesToLabels, toggleLabelDebug, sendDownlinkMessage, sendClearDownlinkQueue, fetchDownlinkQueue, updateLabelNotificationSettings, updateLabelNotificationWebhooks }, dispatch)
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(

--- a/lib/console_web/channels/device_channel.ex
+++ b/lib/console_web/channels/device_channel.ex
@@ -4,4 +4,12 @@ defmodule ConsoleWeb.DeviceChannel do
   def join("device:all", _message, socket) do
     {:ok, socket}
   end
+
+  def handle_in("downlink:update_queue", payload, socket) do
+    IO.inspect payload
+    # check payload for device id and broadcast to the correct device
+    # ConsoleWeb.Endpoint.broadcast("graphql:device_show_downlink", "graphql:device_show_downlink:#{id}:update_queue", payload)
+
+    {:reply, :ok, socket}
+  end
 end

--- a/lib/console_web/channels/graphql_channel.ex
+++ b/lib/console_web/channels/graphql_channel.ex
@@ -88,4 +88,12 @@ defmodule ConsoleWeb.GraphqlChannel do
   def join("graphql:device_import_update", _message, socket) do
     {:ok, socket}
   end
+
+  def join("graphql:device_show_downlink", _message, socket) do
+    {:ok, socket}
+  end
+
+  def join("graphql:label_show_downlink", _message, socket) do
+    {:ok, socket}
+  end
 end

--- a/lib/console_web/channels/label_channel.ex
+++ b/lib/console_web/channels/label_channel.ex
@@ -1,0 +1,15 @@
+defmodule ConsoleWeb.LabelChannel do
+  use Phoenix.Channel
+
+  def join("label:all", _message, socket) do
+    {:ok, socket}
+  end
+
+  def handle_in("downlink:update_queue", payload, socket) do
+    IO.inspect payload
+    # check payload for label id and broadcast to the correct label
+    # ConsoleWeb.Endpoint.broadcast("graphql:label_show_downlink", "graphql:label_show_downlink:#{id}:update_queue", payload)
+
+    {:reply, :ok, socket}
+  end
+end

--- a/lib/console_web/channels/router_socket.ex
+++ b/lib/console_web/channels/router_socket.ex
@@ -3,6 +3,7 @@ defmodule ConsoleWeb.RouterSocket do
 
   channel("device:*", ConsoleWeb.DeviceChannel)
   channel("organization:*", ConsoleWeb.OrganizationChannel)
+  channel("label:*", ConsoleWeb.LabelChannel)
 
   def connect(%{"token" => token}, socket) do
     case ConsoleWeb.Guardian.decode_and_verify(token) do

--- a/lib/console_web/controllers/downlink_controller.ex
+++ b/lib/console_web/controllers/downlink_controller.ex
@@ -2,9 +2,25 @@ defmodule ConsoleWeb.DownlinkController do
   use ConsoleWeb, :controller
 
   alias Console.Devices
+  alias Console.Labels
 
   plug ConsoleWeb.Plug.AuthorizeAction
   action_fallback(ConsoleWeb.FallbackController)
+
+  def fetch_downlink_queue(conn, %{ "id" => id, "type" => type }) do
+    current_organization = conn.assigns.current_organization
+    case type do
+      "device" ->
+        device = Devices.get_device!(current_organization, id)
+        get_device_downlink_queue(device)
+      "label" ->
+        label = Labels.get_label!(current_organization, id)
+        get_label_downlink_queue(label)
+    end
+
+    conn
+    |> send_resp(:no_content, "")
+  end
 
   def clear_downlink_queue(conn, %{ "label_id" => label_id }) do
     devices = Devices.get_devices_for_label(label_id)
@@ -31,5 +47,16 @@ defmodule ConsoleWeb.DownlinkController do
 
   defp clear_downlink_queue(devices) do
     ConsoleWeb.Endpoint.broadcast("device:all", "device:all:clear_downlink_queue:devices", %{ "devices" => devices })
+  end
+
+  defp get_device_downlink_queue(device) do
+    ConsoleWeb.Endpoint.broadcast("device:all", "device:all:downlink:fetch_queue", %{ "device" => device.id })
+  end
+
+  defp get_label_downlink_queue(label) do
+    assoc_device_ids = label |> Labels.fetch_assoc([:devices]) |> Map.get(:devices) |> Enum.map(fn d -> d.id end)
+    if length(assoc_device_ids) > 0 do
+      ConsoleWeb.Endpoint.broadcast("device:all", "device:all:downlink:fetch_queue", %{ "label" => label.id, "devices" => assoc_device_ids })
+    end
   end
 end

--- a/lib/console_web/router.ex
+++ b/lib/console_web/router.ex
@@ -82,6 +82,7 @@ defmodule ConsoleWeb.Router do
     post "/flows/update", FlowsController, :update_edges
 
     post "/clear_downlink_queue", DownlinkController, :clear_downlink_queue
+    get "/downlink_queue", DownlinkController, :fetch_downlink_queue
   end
 
   scope "/api/router", ConsoleWeb.Router do


### PR DESCRIPTION
The high level flow is:

1. When downlink panel is opened, uses downlink controller to tell router that the downlink queue is being requested.
2. Router receives the message, and sends the queue through sockets to the device:all and label:all channels in console. 
3. Console gets these payloads and sockets them up to the front-end through graphql:device_show_downlink and graphql:label_show_downlink channels

The front-end UI has not been implemented yet, waiting on payload sample from router team.