### PR TITLE
Deleting device on device show page does not remove from device table upon redirect

### DIFF
--- a/assets/js/components/devices/DeviceIndex.jsx
+++ b/assets/js/components/devices/DeviceIndex.jsx
@@ -54,6 +54,11 @@ class DeviceIndex extends Component {
       this.refetchPaginatedEntries(page, pageSize, column, order)
     })
 
+    if (!this.props.devicesQuery.loading) {
+      const { page, pageSize, column, order } = this.state
+      this.refetchPaginatedEntries(page, pageSize, column, order)
+    }
+
     this.importChannel = socket.channel("graphql:device_import_update", {})
     this.importChannel.join()
     this.importChannel.on(`graphql:device_import_update:${currentOrganizationId}:import_list_updated`, (message) => {


### PR DESCRIPTION
PR ensures we refetch after devices is done loading upon redirect from deleting in device show page

```
...............................................

Finished in 1.1 seconds
49 tests, 0 failures
```