### PR TITLE
Fix debug on w/ new event

### DIFF
--- a/assets/js/components/common/DebugEntry.jsx
+++ b/assets/js/components/common/DebugEntry.jsx
@@ -204,7 +204,7 @@ class DebugEntry extends Component {
                       "id": event.data.integration.id,
                       "name": event.data.integration.name,
                       "status": event.data.integration.status,
-                      "decoded_payload": event.data.req && event.data.req.body.decoded && event.data.req.body.decoded.payload
+                      "decoded_payload": event.data.req && event.data.req.body && event.data.req.body.decoded && event.data.req.body.decoded.payload
                     }, null, 2
                 )}
               </pre>


### PR DESCRIPTION
When a new event comes in through debug, there is an unrecoverable error due to the fact that `body` may not always be in the `req`