### PR TITLE
Fix packet graph

### DIFF
--- a/assets/js/components/common/PacketGraph.jsx
+++ b/assets/js/components/common/PacketGraph.jsx
@@ -44,10 +44,10 @@ class PacketGraph extends Component {
           ticks: {
             beginAtZero: true,
             min: 0,
-            max: 300,
-            stepSize: 30,
+            max: 300000,
+            stepSize: 30000,
             callback: (value) => {
-              if (value !== 0) return '-' + value + 's';
+              if (value !== 0) return '-' + (parseInt(value)/1000) + 's';
               else return value + 's'
             }
           },
@@ -101,13 +101,13 @@ class PacketGraph extends Component {
     const noIntegration = []
 
     events.forEach(event => {
-      const currentTime = Date.now() / 1000
-      const eventTime =  parseInt(event.reported_at) / 1000
+      const currentTime = Date.now()
+      const eventTime =  parseInt(event.reported_at)
       const timeDiff = currentTime - eventTime
       const integrations = event.integrations
       const hotspots = event.hotspots
 
-      if (timeDiff < 300) {
+      if (timeDiff < 300000) {
         if (integrations[0] && integrations[0].status == 'success') {
           success.push({
             x: timeDiff,


### PR DESCRIPTION
Previously, the graph was using time in seconds and causing things like this:
![image](https://user-images.githubusercontent.com/51131939/111391823-9b9bba00-8672-11eb-927e-39f9f6546d23.png)

Instead, graph should use data point's time in milliseconds to more accurately place the dot, while keeping the axis labels the same by converting those to seconds.
