### PR TITLE
Fix type displayed for confirmed/unconfirmed uplinks

### DIFF
--- a/assets/js/components/events/EventsDashboard.jsx
+++ b/assets/js/components/events/EventsDashboard.jsx
@@ -32,19 +32,21 @@ const base64ToHex = str => {
   return result.toUpperCase();
 }
 
-const confirmedTag = (confirmed) => {
-  if (confirmed) {
+const confirmedTag = (subCategories) => {
+  if (subCategories.includes('uplink_confirmed') || subCategories.includes('downlink_confirmed')) {
     return (
       <React.Fragment>
         (Confirmed <CheckSquareFilled style={{ fontSize: '15px', color: 'green' }} />)
       </React.Fragment>
     );
-  } else {
+  } else if (subCategories.includes('uplink_unconfirmed') || subCategories.includes('downlink_unconfirmed')) {
     return (
       <React.Fragment>
         (Unconfirmed <CloseSquareFilled style={{ fontSize: '15px', color: 'deepskyblue' }} />)
       </React.Fragment>
     );
+  } else {
+    return;
   }
 }
 
@@ -53,10 +55,8 @@ const categoryTag = (category, subCategories) => {
     case "uplink":
       if (subCategories.includes('uplink_dropped')) {
         return <Text>Uplink Dropped</Text>;
-      } else if (subCategories.includes('uplink_integration_req') || subCategories.includes('uplink_integration_res')) {
-        return <Text>Uplink</Text>;
       } else {
-        return <Text>Uplink {confirmedTag(subCategories.includes('uplink_confirmed'))}</Text>;
+        return <Text>Uplink {confirmedTag(subCategories)}</Text>;
       }
     case "downlink":
       if (subCategories.includes('downlink_dropped')) {
@@ -64,7 +64,7 @@ const categoryTag = (category, subCategories) => {
       } else if (subCategories.includes('downlink_ack')) {
         return <Text>Acknowledge</Text>;
       } else {
-        return <Text>Downlink ({subCategories.includes('downlink_confirmed') ? 'Confirmed' : 'Unconfirmed'})</Text>;
+        return <Text>Downlink {confirmedTag(subCategories)}</Text>;
       }
     case "join_request":
       return <Text>Join Request</Text>


### PR DESCRIPTION
The same router UUID event will have a `uplink_integration_res`/`req` and `uplink_confirmed`/`unconfirmed` so they should be labeled appropriately.