### PR TITLE
Fix orphaning events

### DIFF
--- a/assets/js/components/events/EventsDashboard.jsx
+++ b/assets/js/components/events/EventsDashboard.jsx
@@ -321,6 +321,10 @@ class EventsDashboard extends Component {
 
     aggregatedRows.sort((a, b) => (a.reported_at < b.reported_at) ? 1 : -1);
 
+    // prevent orphaning events since they come in decoupled
+    // 50 as we expect ~3 rows per event
+    if (aggregatedRows.length > 50) aggregatedRows.pop();
+
     const columns = [
       {
         title: 'Frame Count',

--- a/lib/console/devices/device_resolver.ex
+++ b/lib/console/devices/device_resolver.ex
@@ -124,7 +124,7 @@ defmodule Console.Devices.DeviceResolver do
 
     events = Event
       |> where([e], e.device_id == ^device.id)
-      |> limit(50)
+      |> limit(150)
       |> order_by(desc: :reported_at_naive)
       |> Repo.all()
 


### PR DESCRIPTION
Assumption:
An event will probably have around ~3 related rows (since they come in decoupled from router)

Thus if we pull in 150 rows, we should have around 50 aggregated events

Get rid of the last one to prevent any subevents getting orphaned and thus showing w/ no frame count, etc.