### PR TITLE
Fix device table not updating frame_up and frame_down

### DIFF
--- a/lib/console_web/controllers/router/device_controller.ex
+++ b/lib/console_web/controllers/router/device_controller.ex
@@ -153,8 +153,8 @@ defmodule ConsoleWeb.Router.DeviceController do
 
             Devices.update_device(device, %{
               "last_connected" => event.reported_at_naive,
-              "frame_up" => event.data["frame_up"],
-              "frame_down" => event.data["frame_down"],
+              "frame_up" => event.frame_up,
+              "frame_down" => event.frame_down,
               "total_packets" => device.total_packets + packet_count,
               "dc_usage" => device.dc_usage + dc_used,
             }, "router")


### PR DESCRIPTION
Access `frame_up` and `frame_down` fields from the created event properly to be able to update the device.

```

...............................................

Finished in 1.3 seconds
49 tests, 0 failures
```