### PR TITLE
Filter out certain type of dropped events by default

### DIFF
--- a/assets/js/components/events/EventsDashboard.jsx
+++ b/assets/js/components/events/EventsDashboard.jsx
@@ -328,7 +328,7 @@ class EventsDashboard extends Component {
     if (aggregatedRows.length > 50) aggregatedRows.pop();
 
 
-    // handle filtering of dropped packets
+    // handle filtering of dropped uplinks
     if (!this.state.showInactive) {
       aggregatedRows = aggregatedRows.filter(row => row.sub_categories[0] !== 'uplink_dropped_device_inactive');
     }
@@ -389,14 +389,14 @@ class EventsDashboard extends Component {
             </Checkbox>
 
             <Text strong style={{ marginLeft: 40, fontSize: 13, color: 'rgba(0, 0, 0, 0.85)'}}>
-              Show Dropped Packets:
+              Show Dropped Uplinks:
             </Text>
             <Checkbox
               onChange={() => this.toggleShowLate()}
               checked={showLate}
               style={{ marginLeft: 20 }}
             >
-              Late Arrival
+              Late
             </Checkbox>
             <Checkbox
               onChange={() => this.toggleShowInactive()}

--- a/assets/js/components/events/EventsDashboard.jsx
+++ b/assets/js/components/events/EventsDashboard.jsx
@@ -52,16 +52,14 @@ const confirmedTag = (subCategories) => {
 
 const categoryTag = (category, subCategories) => {
   switch(category) {
+    case "uplink_dropped":
+      return <Text>Uplink Dropped</Text>;
     case "uplink":
-      if (subCategories.includes('uplink_dropped')) {
-        return <Text>Uplink Dropped</Text>;
-      } else {
-        return <Text>Uplink {confirmedTag(subCategories)}</Text>;
-      }
+      return <Text>Uplink {confirmedTag(subCategories)}</Text>;
+    case "downlink_dropped":
+      return <Text>Downlink Dropped</Text>;
     case "downlink":
-      if (subCategories.includes('downlink_dropped')) {
-        return <Text>Downlink Dropped</Text>;
-      } else if (subCategories.includes('downlink_ack')) {
+      if (subCategories.includes('downlink_ack')) {
         return <Text>Acknowledge</Text>;
       } else {
         return <Text>Downlink {confirmedTag(subCategories)}</Text>;
@@ -96,6 +94,8 @@ class EventsDashboard extends Component {
     rows: [],
     expandedRowKeys: [],
     expandAll: false,
+    showLate: false,
+    showInactive: false
   }
 
   componentDidUpdate(prevProps) {
@@ -138,6 +138,14 @@ class EventsDashboard extends Component {
     } else {
       this.setState({ expandAll: true, expandedRowKeys: aggregatedRows.map(r => r.id) })
     }
+  }
+
+  toggleShowLate = () => {
+    this.setState({ showLate: !this.state.showLate });
+  }
+
+  toggleShowInactive = () => {
+    this.setState({ showInactive: !this.state.showInactive });
   }
 
   onExpandRow = (expandRow, row) => {
@@ -209,62 +217,56 @@ class EventsDashboard extends Component {
 
   renderFrameIcons = row => {
     switch(row.category) {
+      case "uplink_dropped":
+        return (
+          <span>
+            <Tag style={styles.tag} color="#D9D9D9">
+              <CloseOutlined style={{ fontSize: 16, marginRight: 3, position: 'relative', top: 1.5 }} />
+              {row.fct}
+            </Tag>
+            <Popover
+              content={row.description}
+              placement="top"
+              overlayStyle={{ width: 220 }}
+            >
+              <Tag style={{ ...styles.tag, paddingRight: 0, cursor: "pointer" }} color="#D9D9D9">
+                <InfoOutlined style={{ marginLeft: -4, marginRight: 3 }} />
+              </Tag>
+            </Popover>
+          </span>
+        );
       case "uplink":
-        // per router, uplink_dropped will never be associated to another subcategory of uplink
-        if (row.sub_categories.includes('uplink_dropped')) {
-          return (
-            <span>
-              <Tag style={styles.tag} color="#D9D9D9">
-                <CloseOutlined style={{ fontSize: 16, marginRight: 3, position: 'relative', top: 1.5 }} />
-                {row.fct}
-              </Tag>
-              <Popover
-                content={row.description}
-                placement="top"
-                overlayStyle={{ width: 220 }}
-              >
-                <Tag style={{ ...styles.tag, paddingRight: 0, cursor: "pointer" }} color="#D9D9D9">
-                  <InfoOutlined style={{ marginLeft: -4, marginRight: 3 }} />
-                </Tag>
-              </Popover>
-            </span>
-          );
-        } else {
-          return (
-            <Tag style={styles.tag} color="#4091F7">
-              <CaretUpOutlined style={{ marginRight: 1 }}/>
+        return (
+          <Tag style={styles.tag} color="#4091F7">
+            <CaretUpOutlined style={{ marginRight: 1 }}/>
+            {row.fct}
+          </Tag>
+        );
+      case "downlink_dropped":
+        return (
+          <span>
+            <Tag style={styles.tag} color="#D9D9D9">
+              <CloseOutlined style={{ fontSize: 16, marginRight: 3, position: 'relative', top: 1.5 }} />
               {row.fct}
             </Tag>
-          )
-        }
+            <Popover
+              content={row.description}
+              placement="top"
+              overlayStyle={{ width: 220 }}
+            >
+              <Tag style={{ ...styles.tag, paddingRight: 0, cursor: "pointer" }} color="#D9D9D9">
+                <InfoOutlined style={{ marginLeft: -4, marginRight: 3 }} />
+              </Tag>
+            </Popover>
+          </span>
+        );
       case "downlink":
-        // per router, downlink_dropped will never be associated to another subcategory of downlink
-        if (row.sub_categories.includes('downlink_dropped')) {
-          return (
-            <span>
-              <Tag style={styles.tag} color="#D9D9D9">
-                <CloseOutlined style={{ fontSize: 16, marginRight: 3, position: 'relative', top: 1.5 }} />
-                {row.fct}
-              </Tag>
-              <Popover
-                content={row.description}
-                placement="top"
-                overlayStyle={{ width: 220 }}
-              >
-                <Tag style={{ ...styles.tag, paddingRight: 0, cursor: "pointer" }} color="#D9D9D9">
-                  <InfoOutlined style={{ marginLeft: -4, marginRight: 3 }} />
-                </Tag>
-              </Popover>
-            </span>
-          );
-        } else {
-          return (
-            <Tag style={styles.tag} color="#FA541C">
-              <CaretDownOutlined style={{ marginRight: 1 }}/>
-              {row.fct}
-            </Tag>
-          );
-        }
+        return (
+          <Tag style={styles.tag} color="#FA541C">
+            <CaretDownOutlined style={{ marginRight: 1 }}/>
+            {row.fct}
+          </Tag>
+        );
       case "join_request":
       case "join_accept":
         return (
@@ -287,10 +289,10 @@ class EventsDashboard extends Component {
   }
 
   render() {
-    const { rows, expandedRowKeys, expandAll } = this.state
+    const { rows, expandedRowKeys, expandAll, showLate, showInactive } = this.state
 
     // events will come in separately and related events will have same router_uuid
-    const aggregatedRows = Object.values(groupBy(rows, 'router_uuid')).map(routerEvents => {
+    let aggregatedRows = Object.values(groupBy(rows, 'router_uuid')).map(routerEvents => {
       const orderedRouterEvents = sortBy(routerEvents, ["reported_at"]);
       let firstEvent = orderedRouterEvents[0];
 
@@ -324,6 +326,16 @@ class EventsDashboard extends Component {
     // prevent orphaning events since they come in decoupled
     // 50 as we expect ~3 rows per event
     if (aggregatedRows.length > 50) aggregatedRows.pop();
+
+
+    // handle filtering of dropped packets
+    if (!this.state.showInactive) {
+      aggregatedRows = aggregatedRows.filter(row => row.sub_categories[0] !== 'uplink_dropped_device_inactive');
+    }
+
+    if (!this.state.showLate) {
+      aggregatedRows = aggregatedRows.filter(row => row.sub_categories[0] !== 'uplink_dropped_late');
+    }
 
     const columns = [
       {
@@ -374,6 +386,24 @@ class EventsDashboard extends Component {
               style={{ marginLeft: 20 }}
             >
               Expand All
+            </Checkbox>
+
+            <Text strong style={{ marginLeft: 40, fontSize: 13, color: 'rgba(0, 0, 0, 0.85)'}}>
+              Show Dropped Packets:
+            </Text>
+            <Checkbox
+              onChange={() => this.toggleShowLate()}
+              checked={showLate}
+              style={{ marginLeft: 20 }}
+            >
+              Late Arrival
+            </Checkbox>
+            <Checkbox
+              onChange={() => this.toggleShowInactive()}
+              checked={showInactive}
+              style={{ marginLeft: 20 }}
+            >
+              Inactive Device
             </Checkbox>
           </span>
           <a

--- a/lib/console_web/controllers/router/device_controller.ex
+++ b/lib/console_web/controllers/router/device_controller.ex
@@ -112,13 +112,13 @@ defmodule ConsoleWeb.Router.DeviceController do
       |> Map.delete("id")
 
     event = case event["category"] do
-      category when category in ["uplink", "join_request", "join_accept"] ->
+      category when category in ["uplink", "join_request", "join_accept", "uplink_dropped"] ->
         cond do
           is_integer(event["data"]["fcnt"]) -> event |> Map.put("frame_up", event["data"]["fcnt"])
           event["data"]["fcnt"] != nil and Integer.parse(event["data"]["fcnt"]) != :error -> event |> Map.put("frame_up", event["data"]["fcnt"])
           true -> event |> Map.put("frame_up", nil)
         end
-      "downlink" ->
+      category when category in ["downlink", "downlink_dropped"] ->
         cond do
           is_integer(event["data"]["fcnt"]) -> event |> Map.put("frame_down", event["data"]["fcnt"])
           event["data"]["fcnt"] != nil and Integer.parse(event["data"]["fcnt"]) != :error -> event |> Map.put("frame_down", event["data"]["fcnt"])


### PR DESCRIPTION
Add filtering checkboxes for hiding dropped uplink events due to: 1) late and 2) device inactive by default.

![image](https://user-images.githubusercontent.com/51131939/111544196-57bbba00-8731-11eb-9d8c-b0b520f7ca31.png)



```

...............................................

Finished in 1.2 seconds
49 tests, 0 failures
```