### PR TITLE
Conditionally update device frame_up, frame_down when event is received

### DIFF
--- a/lib/console_web/controllers/router/device_controller.ex
+++ b/lib/console_web/controllers/router/device_controller.ex
@@ -151,13 +151,19 @@ defmodule ConsoleWeb.Router.DeviceController do
               end
             packet_count = if dc_used == 0, do: 0, else: 1
 
-            Devices.update_device(device, %{
+            device_updates = %{
               "last_connected" => event.reported_at_naive,
-              "frame_up" => event.frame_up,
-              "frame_down" => event.frame_down,
               "total_packets" => device.total_packets + packet_count,
               "dc_usage" => device.dc_usage + dc_used,
-            }, "router")
+            }
+
+            device_updates = cond do
+              is_integer(event.frame_up) -> device_updates |> Map.put("frame_up", event.frame_up)
+              is_integer(event.frame_down) -> device_updates |> Map.put("frame_down", event.frame_up)
+              true -> device_updates
+            end
+
+            Devices.update_device(device, device_updates, "router")
           end)
           |> Ecto.Multi.run(:device_stat, fn _repo, %{ event: event, device: device } ->
             if event.sub_category in ["uplink_confirmed", "uplink_unconfirmed"] do

--- a/lib/console_web/controllers/router/device_controller.ex
+++ b/lib/console_web/controllers/router/device_controller.ex
@@ -159,7 +159,7 @@ defmodule ConsoleWeb.Router.DeviceController do
 
             device_updates = cond do
               is_integer(event.frame_up) -> device_updates |> Map.put("frame_up", event.frame_up)
-              is_integer(event.frame_down) -> device_updates |> Map.put("frame_down", event.frame_up)
+              is_integer(event.frame_down) -> device_updates |> Map.put("frame_down", event.frame_down)
               true -> device_updates
             end
 


### PR DESCRIPTION
events of sub_category uplink_integration_req and uplink_integration_res were overwriting the frame_up and frame_down for devices with null since they don't have fcnt -> this PR conditionally updates devices if the frame_up or frame_down is an int (not null)

```

................................................

Finished in 1.6 seconds
49 tests, 0 failures
```