### PR TITLE
Event log integration error icon must show for multiple integrations

### DIFF
--- a/assets/js/components/events/EventsDashboard.jsx
+++ b/assets/js/components/events/EventsDashboard.jsx
@@ -340,8 +340,8 @@ class EventsDashboard extends Component {
         title: 'Type',
         dataIndex: 'category',
         render: (data, row) => {
-          const integrationResponse = row.integrations && row.integrations.find(i => i.subCategory === 'uplink_integration_res');
-          const integrationError = integrationResponse && integrationResponse.status === 'error';
+          const integrationResponses = row.integrations && row.integrations.filter(i => i.subCategory === 'uplink_integration_res');
+          const integrationError = integrationResponses.findIndex(i => i.status === 'error') === -1 ? false : true;
           return <Text>{categoryTag(row.category, row.sub_categories, integrationError)}</Text>;
         }
       },


### PR DESCRIPTION
Previously, if an event row had a successful integration response and an errored one, it would not show the integration error icon since it did not account for multiple integration responses coming in. 

This PR changes it so that it shows the error icon if any of the responses had errors.