### PR TITLE
Limit event exports to 1440

### DIFF
--- a/lib/console/devices/devices.ex
+++ b/lib/console/devices/devices.ex
@@ -158,11 +158,9 @@ defmodule Console.Devices do
     |> Repo.update_all(set: [active: active])
   end
 
-  def get_all_events_last_day(device_id) do
-    current_unix = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
-    unix1d = current_unix - 86400000
-
-    from(e in Event, where: e.device_id == ^device_id and e.reported_at_epoch > ^unix1d)
+  def get_events(device_id) do
+    from(e in Event, where: e.device_id == ^device_id)
+    |> limit(1440)
     |> Repo.all()
   end
 end

--- a/lib/console_web/controllers/device_controller.ex
+++ b/lib/console_web/controllers/device_controller.ex
@@ -453,8 +453,8 @@ defmodule ConsoleWeb.DeviceController do
     ConsoleWeb.Endpoint.broadcast("device:all", "device:all:refetch:devices", %{ "devices" => [device.id] })
   end
 
-  def get_all_events(conn, %{ "device_id" => device_id }) do
-    events = Devices.get_all_events_last_day(device_id)
+  def get_events(conn, %{ "device_id" => device_id }) do
+    events = Devices.get_events(device_id)
 
     conn
     |> put_status(:ok)

--- a/lib/console_web/router.ex
+++ b/lib/console_web/router.ex
@@ -40,7 +40,7 @@ defmodule ConsoleWeb.Router do
     post "/devices/delete", DeviceController, :delete
     post "/devices/debug", DeviceController, :debug
     post "/devices/set_active", DeviceController, :set_active
-    get "/devices/:device_id/events", DeviceController, :get_all_events
+    get "/devices/:device_id/events", DeviceController, :get_events
     get "/ttn/devices", DeviceController, :get_ttn
     post "/ttn/devices/import", DeviceController, :import_ttn
     post "/generic/devices/import", DeviceController, :import_generic

--- a/lib/console_web/views/event_view.ex
+++ b/lib/console_web/views/event_view.ex
@@ -24,7 +24,8 @@ defmodule ConsoleWeb.EventView do
       frame_up: event.frame_up,
       frame_down: event.frame_down,
       organization_id: event.organization_id,
-      router_uuid: event.router_uuid
+      router_uuid: event.router_uuid,
+      device_id: event.device_id
     }
   end
 


### PR DESCRIPTION
1440: roughly enough for every 5 mins for 24 hrs 
Also adding `device_id`