### PR TITLE
Drop last event when adding new event

### DIFF
--- a/assets/js/components/events/EventsDashboard.jsx
+++ b/assets/js/components/events/EventsDashboard.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { formatDatetime } from '../../util/time'
+import { formatDatetime, getDiffInSeconds } from '../../util/time'
 import analyticsLogger from '../../util/analyticsLogger';
 import groupBy from 'lodash/groupBy';
 import sortBy from 'lodash/sortBy';
@@ -117,13 +117,21 @@ class EventsDashboard extends Component {
 
   addEvent = event => {
     const { rows, expandAll } = this.state
-
     const expandedRowKeys = expandAll ? this.state.expandedRowKeys.concat(event.id) : this.state.expandedRowKeys
 
-    this.setState({
-      rows: [event].concat(rows),
-      expandedRowKeys
-    })
+    const lastEvent = rows[rows.length - 1];
+    if (rows.length > 100 && getDiffInSeconds(parseInt(lastEvent.reported_at)) > 300) {
+      const lastRouterId = lastEvent.router_uuid;
+      this.setState({
+        rows: [event].concat(rows.filter(event => (event.router_uuid !== lastRouterId))),
+        expandedRowKeys
+      })
+    } else {
+      this.setState({
+        rows: [event].concat(rows),
+        expandedRowKeys
+      })
+    }
   }
 
   toggleExpandAll = (aggregatedRows) => {

--- a/lib/console/devices/device_resolver.ex
+++ b/lib/console/devices/device_resolver.ex
@@ -124,7 +124,7 @@ defmodule Console.Devices.DeviceResolver do
 
     events = Event
       |> where([e], e.device_id == ^device.id)
-      |> limit(250)
+      |> limit(150)
       |> order_by(desc: :reported_at_naive)
       |> Repo.all()
 


### PR DESCRIPTION
Preventing the orphaning of events when dropping the oldest event at the time of adding a new one so that the event log doesn't get annoyingly long on the browser. Leaving splice on render as a way to ensure what we grab from db isn't orphaning as well.