### PR TITLE
Discovery Mode

### DIFF
--- a/lib/console/devices/device.ex
+++ b/lib/console/devices/device.ex
@@ -24,6 +24,7 @@ defmodule Console.Devices.Device do
     field :last_connected, :naive_datetime
     field :dc_usage, :integer
     field :active, :boolean
+    field :hotspot_address, :string
 
     belongs_to :organization, Organization
     has_many :events, Event, on_delete: :delete_all
@@ -44,6 +45,24 @@ defmodule Console.Devices.Device do
       |> validate_required([:name, :dev_eui, :app_eui, :app_key, :oui, :organization_id])
       |> validate_length(:name, max: 50, message: "Name cannot be longer than 50 characters")
       |> unique_constraint(:dev_eui, name: :devices_dev_eui_app_eui_app_key_index, message: "Please choose device credentials with unique dev_eui, app_eui, and app_key")
+  end
+
+  def create_discovery_changeset(device, %{ "hotspot_address" => hotspot_address, "organization_id" => organization_id }) do
+    alphabet = '0123456789ABCDEF'
+    attrs = %{
+      "name" => "hotspot-" <> hotspot_address,
+      "hotspot_address" => hotspot_address,
+      "dev_eui" => Helpers.generate_string(16, alphabet),
+      "app_eui" => Helpers.generate_string(16, alphabet),
+      "app_key" => Helpers.generate_string(32, alphabet),
+      "organization_id" => organization_id
+    }
+
+    changeset =
+      device
+      |> cast(attrs, [:name, :dev_eui, :app_eui, :app_key, :hotspot_address, :organization_id])
+      |> put_change(:oui, Application.fetch_env!(:console, :oui))
+      |> validate_required([:name, :dev_eui, :app_eui, :app_key, :oui, :organization_id])
   end
 
   def update_changeset(device, attrs) do

--- a/lib/console/devices/device.ex
+++ b/lib/console/devices/device.ex
@@ -62,7 +62,9 @@ defmodule Console.Devices.Device do
       device
       |> cast(attrs, [:name, :dev_eui, :app_eui, :app_key, :hotspot_address, :organization_id])
       |> put_change(:oui, Application.fetch_env!(:console, :oui))
+      |> check_attrs_format()
       |> validate_required([:name, :dev_eui, :app_eui, :app_key, :oui, :organization_id])
+      |> unique_constraint(:dev_eui, name: :devices_dev_eui_app_eui_app_key_index, message: "Values for dev_eui, app_eui, and app_key must be unique, please try again")
   end
 
   def update_changeset(device, attrs) do

--- a/lib/console/devices/device.ex
+++ b/lib/console/devices/device.ex
@@ -47,20 +47,18 @@ defmodule Console.Devices.Device do
       |> unique_constraint(:dev_eui, name: :devices_dev_eui_app_eui_app_key_index, message: "Please choose device credentials with unique dev_eui, app_eui, and app_key")
   end
 
-  def create_discovery_changeset(device, %{ "hotspot_address" => hotspot_address, "organization_id" => organization_id }) do
+  def create_discovery_changeset(device, device_params = %{ "name" => name, "hotspot_address" => hotspot_address, "organization_id" => organization_id }) do
     alphabet = '0123456789ABCDEF'
-    attrs = %{
-      "name" => "hotspot-" <> hotspot_address,
-      "hotspot_address" => hotspot_address,
-      "dev_eui" => Helpers.generate_string(16, alphabet),
-      "app_eui" => Helpers.generate_string(16, alphabet),
-      "app_key" => Helpers.generate_string(32, alphabet),
-      "organization_id" => organization_id
-    }
+    device_params = 
+      Map.merge(device_params, %{
+        "dev_eui" => Helpers.generate_string(16, alphabet),
+        "app_eui" => Helpers.generate_string(16, alphabet),
+        "app_key" => Helpers.generate_string(32, alphabet),
+      })
 
     changeset =
       device
-      |> cast(attrs, [:name, :dev_eui, :app_eui, :app_key, :hotspot_address, :organization_id])
+      |> cast(device_params, [:name, :dev_eui, :app_eui, :app_key, :hotspot_address, :organization_id])
       |> put_change(:oui, Application.fetch_env!(:console, :oui))
       |> check_attrs_format()
       |> validate_required([:name, :dev_eui, :app_eui, :app_key, :oui, :organization_id])

--- a/lib/console/devices/devices.ex
+++ b/lib/console/devices/devices.ex
@@ -8,6 +8,7 @@ defmodule Console.Devices do
   alias Console.Events.Event
   alias Console.Labels.DevicesLabels
   alias Console.Channels.Channel
+  alias Console.Organizations.Organization
 
   def list_devices do
     Repo.all(Device)
@@ -83,7 +84,7 @@ defmodule Console.Devices do
   def create_device(attrs \\ %{}, %Organization{} = organization) do
     count = get_organization_device_count(organization)
     cond do
-      organization.name !== "Discovery Mode (Helium)" and count > 9999 ->
+      organization.name !== @discovery_mode_org_name and count > 9999 ->
         {:error, :forbidden, "Device limit for organization reached"}
       true ->
         cond do

--- a/lib/console/helpers/helpers.ex
+++ b/lib/console/helpers/helpers.ex
@@ -19,6 +19,10 @@ defmodule Console.Helpers do
     |> binary_part(0, length)
   end
 
+  def generate_string(length, alphabet) do
+    for _ <- 1..length, into: "", do: <<Enum.random(alphabet)>>
+  end
+
   def geocodeLatLng(lat, lng) do
     case HTTPoison.get("https://maps.googleapis.com/maps/api/geocode/json?latlng=#{lat},#{lng}&key=#{Application.get_env(:console, :google_maps_secret)}") do
       {:ok, response} ->

--- a/lib/console/organizations/organization.ex
+++ b/lib/console/organizations/organization.ex
@@ -4,6 +4,8 @@ defmodule Console.Organizations.Organization do
   alias Console.Helpers
   alias Console.Organizations.Organization
 
+  @discovery_mode_org_name "Discovery Mode (Helium)"
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "organizations" do
@@ -78,7 +80,7 @@ defmodule Console.Organizations.Organization do
   defp check_against_discovery_name(changeset) do
     case changeset do
       %Ecto.Changeset{valid?: true, changes: %{name: name}} ->
-        valid_name = name != "Discovery Mode (Helium)"
+        valid_name = name != @discovery_mode_org_name
         case valid_name do
           false -> add_error(changeset, :message, "Please choose a different organization name")
           true -> changeset

--- a/lib/console/organizations/organization.ex
+++ b/lib/console/organizations/organization.ex
@@ -42,6 +42,7 @@ defmodule Console.Organizations.Organization do
     |> validate_required(:name, message: "Organization Name is required")
     |> validate_length(:name, min: 3, message: "Organization Name must be at least 3 letters")
     |> validate_length(:name, max: 50, message: "Organization Name cannot be longer than 50 characters")
+    |> check_against_discovery_name
     |> check_name
     |> put_webhook_key()
   end
@@ -72,6 +73,18 @@ defmodule Console.Organizations.Organization do
     organization
     |> changeset(attrs)
     |> put_assoc(:users, [user])
+  end
+
+  defp check_against_discovery_name(changeset) do
+    case changeset do
+      %Ecto.Changeset{valid?: true, changes: %{name: name}} ->
+        valid_name = name != "Discovery Mode (Helium)"
+        case valid_name do
+          false -> add_error(changeset, :message, "Please choose a different organization name")
+          true -> changeset
+        end
+      _ -> changeset
+    end
   end
 
   defp check_name(changeset) do

--- a/lib/console/organizations/organizations.ex
+++ b/lib/console/organizations/organizations.ex
@@ -79,6 +79,12 @@ defmodule Console.Organizations do
       |> Repo.one()
   end
 
+  def get_discovery_mode_org() do
+    Organization
+      |> where([o], o.name == "Discovery Mode (Helium)")
+      |> Repo.one()
+  end
+
   def get_organization!(id) do
     Repo.get!(Organization, id)
   end

--- a/lib/console_web/controllers/device_controller.ex
+++ b/lib/console_web/controllers/device_controller.ex
@@ -21,7 +21,11 @@ defmodule ConsoleWeb.DeviceController do
   def create(conn, %{"device" => device_params, "label" => label}) do
     current_organization = conn.assigns.current_organization
     user = conn.assigns.current_user
-    device_params = Map.merge(device_params, %{"organization_id" => current_organization.id})
+    device_params = 
+      Map.merge(device_params, %{
+        "organization_id" => current_organization.id
+      })
+      |> Map.drop(["hotspot_address"])
 
     with {:ok, %Device{} = device} <- Devices.create_device(device_params, current_organization) do
       case label["labelApplied"] do

--- a/lib/console_web/controllers/v1/device_controller.ex
+++ b/lib/console_web/controllers/v1/device_controller.ex
@@ -97,7 +97,7 @@ defmodule ConsoleWeb.V1.DeviceController do
     end
   end
 
-  def discover_device(conn, params = %{ "address" => address, "wallet_id" => wallet_id, "signature" => signature }) do
+  def discover_device(conn, params = %{ "hotspot_name" => name, "hotspot_address" => address, "wallet_id" => wallet_id, "signature" => signature }) do
     current_organization = conn.assigns.current_organization
     discovery_mode_organization = Organizations.get_discovery_mode_org()
     if current_organization.id !== discovery_mode_organization.id do
@@ -105,7 +105,7 @@ defmodule ConsoleWeb.V1.DeviceController do
     else
       existing_device = Devices.get_device_for_hotspot_address(address)
       if existing_device == nil do
-        with {:ok, %Device{} = device} <- Devices.create_device(%{ "hotspot_address" => address, "organization_id" => current_organization.id }, current_organization) do
+        with {:ok, %Device{} = device} <- Devices.create_device(%{ "name" => name, "hotspot_address" => address, "organization_id" => current_organization.id }, current_organization) do
           discovery_mode_label = Labels.get_label_by_name("Discovery Mode", discovery_mode_organization.id)
           Labels.add_devices_to_label([device.id], discovery_mode_label.id, current_organization)
           ConsoleWeb.Endpoint.broadcast("device:all", "device:all:discover:devices", %{ "address" => address, "wallet_id" => wallet_id, "signature" => signature, "device_id" => device.id })

--- a/lib/console_web/controllers/v1/device_controller.ex
+++ b/lib/console_web/controllers/v1/device_controller.ex
@@ -103,7 +103,6 @@ defmodule ConsoleWeb.V1.DeviceController do
       {:error, :forbidden, "Request must come from Discovery Mode (Helium) organization"}
     else
       existing_device = Devices.get_device_for_hotspot_address(address)
-
       if existing_device == nil do
         with {:ok, %Device{} = device} <- Devices.create_device(%{ "hotspot_address" => address, "organization_id" => current_organization.id }, current_organization) do
           discovery_mode_label = Labels.get_label_by_name("Discovery Mode", discovery_mode_organization.id)

--- a/lib/console_web/controllers/v1/device_controller.ex
+++ b/lib/console_web/controllers/v1/device_controller.ex
@@ -4,6 +4,7 @@ defmodule ConsoleWeb.V1.DeviceController do
   import Ecto.Query
 
   alias Console.Organizations
+  alias Console.Labels
   alias Console.Devices
   alias Console.Devices.Device
   action_fallback(ConsoleWeb.FallbackController)
@@ -92,6 +93,30 @@ defmodule ConsoleWeb.V1.DeviceController do
       conn
       |> put_status(:created)
       |> render("show.json", device: device)
+    end
+  end
+
+  def discover_device(conn, params = %{ "address" => address, "wallet_id" => wallet_id, "signature" => signature }) do
+    current_organization = conn.assigns.current_organization
+    discovery_mode_organization = Organizations.get_discovery_mode_org()
+    if current_organization.id !== discovery_mode_organization.id do
+      {:error, :forbidden, "Request must come from Discovery Mode (Helium) organization"}
+    else
+      existing_device = Devices.get_device_for_hotspot_address(address)
+
+      if existing_device == nil do
+        with {:ok, %Device{} = device} <- Devices.create_device(%{ "hotspot_address" => address, "organization_id" => current_organization.id }, current_organization) do
+          discovery_mode_label = Labels.get_label_by_name("Discovery Mode", discovery_mode_organization.id)
+          Labels.add_devices_to_label([device.id], discovery_mode_label.id, current_organization)
+          ConsoleWeb.Endpoint.broadcast("device:all", "device:all:discover:devices", %{ "address" => address, "wallet_id" => wallet_id, "signature" => signature, "device_id" => device.id })
+          conn
+            |> send_resp(:ok, "Device created and broadcasted to router")
+        end
+      else
+        ConsoleWeb.Endpoint.broadcast("device:all", "device:all:discover:devices", %{ "address" => address, "wallet_id" => wallet_id, "signature" => signature, "device_id" => existing_device.id })
+        conn
+          |> send_resp(:ok, "Device broadcasted to router")
+      end
     end
   end
 

--- a/lib/console_web/controllers/v1/device_controller.ex
+++ b/lib/console_web/controllers/v1/device_controller.ex
@@ -88,6 +88,7 @@ defmodule ConsoleWeb.V1.DeviceController do
         "organization_id" => current_organization.id,
         "oui" => Application.fetch_env!(:console, :oui)
       })
+      |> Map.drop(["hotspot_address"])
 
     with {:ok, %Device{} = device} <- Devices.create_device(device_params, current_organization) do
       conn

--- a/lib/console_web/plug/rate_limit.ex
+++ b/lib/console_web/plug/rate_limit.ex
@@ -6,13 +6,17 @@ defmodule ConsoleWeb.Plug.RateLimit do
   def call(conn, [action, limit]) do
     ip_address = conn |> get_req_header("cf-connecting-ip") |> List.first()
 
-    case Hammer.check_rate("#{action}:#{ip_address}", 60_000, limit) do
-      {:allow, _count} ->
-        conn
-      {:deny, _limit} ->
-        conn
-        |> send_resp(:too_many_requests, "Too many requests")
-        |> halt()
+    if Mix.env == :test do
+      conn
+    else
+      case Hammer.check_rate("#{action}:#{ip_address}", 60_000, limit) do
+        {:allow, _count} ->
+          conn
+        {:deny, _limit} ->
+          conn
+          |> send_resp(:too_many_requests, "Too many requests")
+          |> halt()
+      end
     end
   end
 end

--- a/lib/console_web/router.ex
+++ b/lib/console_web/router.ex
@@ -120,6 +120,7 @@ defmodule ConsoleWeb.Router do
     post "/labels/:id/multi_buy", LabelController, :update_multi_buy
     post "/labels/:id/notification_email", LabelNotificationSettingsController, :update
     post "/labels/:id/notification_webhook", LabelNotificationWebhooksController, :update
+    post "/devices/discover", DeviceController, :discover_device
   end
 
   if Mix.env == :dev do

--- a/priv/repo/migrations/20210325232307_add_hotspot_address_to_devices_table.exs
+++ b/priv/repo/migrations/20210325232307_add_hotspot_address_to_devices_table.exs
@@ -1,0 +1,17 @@
+defmodule Console.Repo.Migrations.AddHotspotAddressToDevicesTable do
+  use Ecto.Migration
+
+  def up do
+    alter table("devices") do
+      add_if_not_exists :hotspot_address, :string
+    end
+    create index(:devices, [:hotspot_address])
+  end
+
+  def down do
+    drop index(:devices, [:hotspot_address])
+    alter table("devices") do
+      remove :hotspot_address
+    end
+  end
+end

--- a/test/console_web/controllers/device_controller_test.exs
+++ b/test/console_web/controllers/device_controller_test.exs
@@ -36,6 +36,14 @@ defmodule ConsoleWeb.DeviceControllerTest do
         "label" => nil
       }
       assert json_response(resp_conn, 201)
+
+      resp_conn = post conn, device_path(conn, :create), %{
+        "device" => %{ "name" => "discovery", "dev_eui" => "aaaaaaaaaaaaaaa2", "app_eui" => "aaaaaaaaaaaaaaa3", "app_key" => "cccccccccccccccccccccccccccccccc", "hotspot_address" => "some_address" },
+        "label" => nil
+      }
+      device2 = json_response(resp_conn, 201)
+      device2 = Devices.get_device!(device2["id"])
+      assert device2.hotspot_address == nil # device not created through discover endpoint should not have hotspot_address
     end
 
     test "create devices with label linked properly", %{conn: conn} do

--- a/test/console_web/controllers/organization_controller_test.exs
+++ b/test/console_web/controllers/organization_controller_test.exs
@@ -34,5 +34,10 @@ defmodule ConsoleWeb.OrganizationControllerTest do
       resp_conn = delete conn, organization_path(conn, :delete, another_org.id), %{ "destination_org_id" => "no-transfer"}
       assert response(resp_conn, 403) # cannot delete org if user is not admin
     end
+
+    test "cannot create organization with discovery mode org name", %{conn: conn} do
+      resp_conn = post conn, organization_path(conn, :create), %{ "organization" => %{ "name" => "Discovery Mode (Helium)" }}
+      assert response(resp_conn, 422)
+    end
   end
 end

--- a/test/console_web/controllers/v1/v1_device_controller_test.exs
+++ b/test/console_web/controllers/v1/v1_device_controller_test.exs
@@ -81,6 +81,18 @@ defmodule ConsoleWeb.V1DeviceControllerTest do
       resp_conn = build_conn() |> put_req_header("key", key) |> delete("/api/v1/devices/#{device["id"]}")
       assert response(resp_conn, 200) # device show does not give back other org devices
       assert Devices.get_device(device["id"]) == nil
+
+      resp_conn = build_conn()
+        |> put_req_header("key", key)
+        |> post("/api/v1/devices", %{
+          "name" => "discovery device",
+          "dev_eui" => "1111111111111111",
+          "app_eui" => "1111111111111111",
+          "app_key" => "11111111111111111111111111111111",
+          "hotspot_address" => "some_address"
+        })
+      device = json_response(resp_conn, 201)
+      assert device["hotspot_address"] == nil # device not created through discover endpoint should not have hotspot_address
     end
 
     test "discovery mode endpoint works properly", %{"conn": conn} do

--- a/test/console_web/controllers/v1/v1_device_controller_test.exs
+++ b/test/console_web/controllers/v1/v1_device_controller_test.exs
@@ -111,7 +111,8 @@ defmodule ConsoleWeb.V1DeviceControllerTest do
       })
 
       resp_conn = build_conn() |> put_req_header("key", key) |> post("/api/v1/devices/discover", %{
-        "address" => "hotspot_address",
+        "hotspot_name" => "some-hotspot-name",
+        "hotspot_address" => "hotspot_address",
         "wallet_id" => "wallet_id",
         "signature" => "signature"
       })
@@ -119,10 +120,12 @@ defmodule ConsoleWeb.V1DeviceControllerTest do
 
       created_device = List.first(Devices.get_devices_for_label(label.id))
       assert created_device != nil
-      assert created_device.name == "hotspot-hotspot_address"
+      assert created_device.name == "some-hotspot-name"
+      assert created_device.hotspot_address == "hotspot_address"
 
       resp_conn = build_conn() |> put_req_header("key", key) |> post("/api/v1/devices/discover", %{
-        "address" => "hotspot_address",
+        "hotspot_name" => "some-hotspot-name",
+        "hotspot_address" => "hotspot_address",
         "wallet_id" => "wallet_id",
         "signature" => "signature"
       })
@@ -136,9 +139,10 @@ defmodule ConsoleWeb.V1DeviceControllerTest do
         key: :crypto.hash(:sha256, key_2)
       })
       resp_conn = build_conn() |> put_req_header("key", key_2) |> post("/api/v1/devices/discover", %{
-        "address" => "some_other_hotspot_address",
+        "hotspot_address" => "some_other_hotspot_address",
         "wallet_id" => "wallet_id",
-        "signature" => "signature"
+        "signature" => "signature",
+        "hotspot_name" => "some-other-hotspot-name"
       })
       assert response(resp_conn, 403)
     end


### PR DESCRIPTION
- Add `/v1/devices/discover` endpoint for Wallet API to use
- Prevent organization creation with Discovery Mode org name
- Prevent creating a device with `hotspot_address` from other endpoints
- Remove device creation limit for Discovery Mode org
- Bypass the `rate_limit` check for too many requests in `test` environment

Tests passing:
```
.................................................

Finished in 1.1 seconds
51 tests, 0 failures
```