### PR TITLE
Minor fixes on email templates

### DIFF
--- a/lib/console_web/templates/email/api_key_email.html.eex
+++ b/lib/console_web/templates/email/api_key_email.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0 85px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>
@@ -240,7 +235,7 @@
                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                             <tr>
                               <td style="display: flex;justify-content: center;">
-                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/lock.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 120px; left: 0; right: 0; margin: auto;">
+                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/lock.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 150px; left: 0; right: 0; margin: auto;">
                               </td>
                             </tr>
                             <!-- Spacing -->

--- a/lib/console_web/templates/email/data_credit_balance_notice.html.eex
+++ b/lib/console_web/templates/email/data_credit_balance_notice.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>

--- a/lib/console_web/templates/email/data_credit_purchase.html.eex
+++ b/lib/console_web/templates/email/data_credit_purchase.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>

--- a/lib/console_web/templates/email/data_credit_top_up.html.eex
+++ b/lib/console_web/templates/email/data_credit_top_up.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>

--- a/lib/console_web/templates/email/data_credit_transfer.html.eex
+++ b/lib/console_web/templates/email/data_credit_transfer.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>

--- a/lib/console_web/templates/email/delete_organization_notice.html.eex
+++ b/lib/console_web/templates/email/delete_organization_notice.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>

--- a/lib/console_web/templates/email/device_deleted_notification_email.html.eex
+++ b/lib/console_web/templates/email/device_deleted_notification_email.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0 85px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>
@@ -240,7 +235,7 @@
                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                             <tr>
                               <td style="display: flex;justify-content: center;">
-                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 120px; left: 0; right: 0; margin: auto;">
+                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 150px; left: 0; right: 0; margin: auto;">
                               </td>
                             </tr>
                             <!-- Spacing -->

--- a/lib/console_web/templates/email/device_join_otaa_first_time_notification_email.html.eex
+++ b/lib/console_web/templates/email/device_join_otaa_first_time_notification_email.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0 85px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>
@@ -240,7 +235,7 @@
                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                             <tr>
                               <td style="display: flex;justify-content: center;">
-                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 120px; left: 0; right: 0; margin: auto;">
+                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 150px; left: 0; right: 0; margin: auto;">
                               </td>
                             </tr>
                             <!-- Spacing -->

--- a/lib/console_web/templates/email/device_stops_transmitting_notification_email.html.eex
+++ b/lib/console_web/templates/email/device_stops_transmitting_notification_email.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0 85px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>
@@ -240,7 +235,7 @@
                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                             <tr>
                               <td style="display: flex;justify-content: center;">
-                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 120px; left: 0; right: 0; margin: auto;">
+                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 150px; left: 0; right: 0; margin: auto;">
                               </td>
                             </tr>
                             <!-- Spacing -->

--- a/lib/console_web/templates/email/downlink_unsuccessful_notification_email.html.eex
+++ b/lib/console_web/templates/email/downlink_unsuccessful_notification_email.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0 85px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>
@@ -240,7 +235,7 @@
                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                             <tr>
                               <td style="display: flex;justify-content: center;">
-                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 120px; left: 0; right: 0; margin: auto;">
+                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 150px; left: 0; right: 0; margin: auto;">
                               </td>
                             </tr>
                             <!-- Spacing -->

--- a/lib/console_web/templates/email/integration_receives_first_event_notification_email.html.eex
+++ b/lib/console_web/templates/email/integration_receives_first_event_notification_email.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0 85px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>
@@ -240,7 +235,7 @@
                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                             <tr>
                               <td style="display: flex;justify-content: center;">
-                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 120px; left: 0; right: 0; margin: auto;">
+                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 150px; left: 0; right: 0; margin: auto;">
                               </td>
                             </tr>
                             <!-- Spacing -->

--- a/lib/console_web/templates/email/integration_stops_working_notification_email.html.eex
+++ b/lib/console_web/templates/email/integration_stops_working_notification_email.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0 85px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>
@@ -240,7 +235,7 @@
                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                             <tr>
                               <td style="display: flex;justify-content: center;">
-                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 120px; left: 0; right: 0; margin: auto;">
+                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 150px; left: 0; right: 0; margin: auto;">
                               </td>
                             </tr>
                             <!-- Spacing -->

--- a/lib/console_web/templates/email/integration_with_devices_deleted_notification_email.html.eex
+++ b/lib/console_web/templates/email/integration_with_devices_deleted_notification_email.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0 85px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>
@@ -240,7 +235,7 @@
                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                             <tr>
                               <td style="display: flex;justify-content: center;">
-                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 120px; left: 0; right: 0; margin: auto;">
+                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 150px; left: 0; right: 0; margin: auto;">
                               </td>
                             </tr>
                             <!-- Spacing -->

--- a/lib/console_web/templates/email/integration_with_devices_updated_notification_email.html.eex
+++ b/lib/console_web/templates/email/integration_with_devices_updated_notification_email.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0 85px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>
@@ -240,7 +235,7 @@
                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                             <tr>
                               <td style="display: flex;justify-content: center;">
-                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 120px; left: 0; right: 0; margin: auto;">
+                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/bell.png") %>" width="80" border="0" height="80" alt="security_image" style="position: absolute; top: 150px; left: 0; right: 0; margin: auto;">
                               </td>
                             </tr>
                             <!-- Spacing -->

--- a/lib/console_web/templates/email/invitation_email.html.eex
+++ b/lib/console_web/templates/email/invitation_email.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0 85px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>
@@ -240,7 +235,7 @@
                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                             <tr>
                               <td style="display: flex;justify-content: center;">
-                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/added.png") %>" width="90" border="0" height="90" alt="security_image" style="position: absolute; top: 120px; left: 0; right: 0; margin: auto;">
+                                  <img src="<%= static_url(ConsoleWeb.Endpoint, "/images/added.png") %>" width="90" border="0" height="90" alt="security_image" style="position: absolute; top: 150px; left: 0; right: 0; margin: auto;">
                               </td>
                             </tr>
                             <!-- Spacing -->

--- a/lib/console_web/templates/email/payment_method_change.html.eex
+++ b/lib/console_web/templates/email/payment_method_change.html.eex
@@ -222,17 +222,12 @@
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
 		        <!-- Email Header : BEGIN -->
 	            <tr>
-	                <td align="center" style="padding: 20px 0;">
+	                <td align="center" style="padding: 55px 0;">
                   <!-- Helium Logo Image -->
-                      <a target="_blank" href="#"><img width="54" border="0" height="54" alt="helium_logo" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
+                      <a target="_blank" href="#"><img width="54" border="0" height="54" style="display:block; border:none; outline:none; text-decoration:none;" src="<%= static_url(ConsoleWeb.Endpoint, "/images/logo.png") %>"></a>
                   </td>
 	            </tr>
 		        <!-- Email Header : END -->
-            <!-- Spacing -->
-              <tr>
-                <td width="100%" height="65"></td>
-              </tr>
-            <!-- Spacing -->
 
                 <!-- 1 Column Text + Button : BEGIN -->
                 <tr>


### PR DESCRIPTION
- Remove the `alt_text` for the logo at the top of the emails which was making it show up on email previews:
![image](https://user-images.githubusercontent.com/51131939/112878384-b7dd2500-907c-11eb-9336-0ebf1332f580.png)

- Fix padding of top logo