### PR TITLE
Scroll to top of event log when expanding all

### DIFF
--- a/assets/js/components/events/EventsDashboard.jsx
+++ b/assets/js/components/events/EventsDashboard.jsx
@@ -88,6 +88,11 @@ const messageType = subCategory => {
 }
 
 class EventsDashboard extends Component {
+  constructor(props) {
+    super(props);
+    this.listRef = React.createRef();
+  }
+
   state = {
     rows: [],
     expandedRowKeys: [],
@@ -138,7 +143,9 @@ class EventsDashboard extends Component {
     if (this.state.expandAll) {
       this.setState({ expandAll: false, expandedRowKeys: [] })
     } else {
-      this.setState({ expandAll: true, expandedRowKeys: aggregatedRows.map(r => r.id) })
+      this.setState({ expandAll: true, expandedRowKeys: aggregatedRows.map(r => r.id) }, () => {
+        this.listRef.current.scrollIntoView(); // prevent scrolling to bottom
+      })
     }
   }
 
@@ -439,15 +446,17 @@ class EventsDashboard extends Component {
               Export JSON
             </Button>
         </div>
-        <Table
-          dataSource={aggregatedRows}
-          columns={columns}
-          rowKey={record => record.id}
-          pagination={false}
-          expandedRowRender={this.renderExpanded}
-          expandedRowKeys={expandedRowKeys}
-          onExpand={this.onExpandRow}
-        />
+        <div ref={this.listRef}>
+          <Table
+            dataSource={aggregatedRows}
+            columns={columns}
+            rowKey={record => record.id}
+            pagination={false}
+            expandedRowRender={this.renderExpanded}
+            expandedRowKeys={expandedRowKeys}
+            onExpand={this.onExpandRow}
+          />
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
This PR ensures we scroll to the top of the event log when expanding all. Previously it would scroll all the way to the bottom.