### PR TITLE
Use internal action to deselect node when we close info sidebar

### DIFF
--- a/assets/js/components/common/Sidebar.jsx
+++ b/assets/js/components/common/Sidebar.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { CloseOutlined } from '@ant-design/icons';
+import { debugSidebarBackgroundColor } from '../../util/colors'
 import { Typography, Tooltip, Button } from 'antd';
 const { Text } = Typography
 
@@ -21,7 +21,7 @@ class Sidebar extends Component {
   }
 
   render() {
-    const { show, width, iconPosition, sidebarIcon, iconBackground, disabled, disabledMessage, message, backgroundColor } = this.props;
+    const { show, iconPosition, sidebarIcon, iconBackground, disabled, disabledMessage, message } = this.props;
     let topPercentage;
     switch (iconPosition) {
       case 'top':
@@ -36,56 +36,44 @@ class Sidebar extends Component {
     return (
       <div
         style={{
-          background: backgroundColor,
+          background: debugSidebarBackgroundColor,
           position: 'absolute',
           top: 55,
-          width: show ? width : 0,
+          width: show ? 650 : 0,
           height: 'calc(100vh - 55px)',
           right: 0,
           zIndex: show ? 10 : 1,
           padding: 0,
-          transition: 'all 0.5s ease',
-          boxShadow: '10px 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19)'
+          transition: 'all 0.5s ease'
         }}
       >
-        {this.props.sidebarIcon && 
-          <Tooltip title={disabled ? disabledMessage : message} placement='left'>
-            <div
-              style={{
-                position: 'relative',
-                left: '-60px',
-                width: 50,
-                height: 50,
-                top: `calc(${topPercentage}% - 25px)`,
-                backgroundColor: disabled ? 'grey' : iconBackground,
-                borderRadius: '9999px',
-                cursor: disabled ? 'not-allowed' : 'pointer',
-                userSelect: 'none'
-              }}
-              onClick={this.handleToggle}
-            >
-              <Text style={{
-                color: 'white',
-                fontSize: 25,
-                position: 'absolute',
-                top: '50%',
-                left: '50%',
-                transform:'translate(-50% , -50%)'
-              }}>
-                {sidebarIcon}
-              </Text>
-            </div>
-          </Tooltip>
-        }
-        {
-          !this.props.sidebarIcon && show && (
-            <Button 
-              style={{ border: 'none', top: '35px', left: '35px' }} 
-              onClick={this.handleToggle} 
-              icon={<CloseOutlined style={{ fontSize: 30, color: '#D2DDE8' }} />}
-            />
-          )
-        }
+        <Tooltip title={disabled ? disabledMessage : message} placement='left'>
+          <div
+            style={{
+              position: 'relative',
+              left: '-60px',
+              width: 50,
+              height: 50,
+              top: `calc(${topPercentage}% - 25px)`,
+              backgroundColor: disabled ? 'grey' : iconBackground,
+              borderRadius: '9999px',
+              cursor: disabled ? 'not-allowed' : 'pointer',
+              userSelect: 'none'
+            }}
+            onClick={this.handleToggle}
+          >
+            <Text style={{
+              color: 'white',
+              fontSize: 25,
+              position: 'absolute',
+              top: '50%',
+              left: '50%',
+              transform:'translate(-50% , -50%)'
+            }}>
+              {sidebarIcon}
+            </Text>
+          </div>
+        </Tooltip>
         {
           show && this.props.children
         }

--- a/assets/js/components/devices/DeviceShow.jsx
+++ b/assets/js/components/devices/DeviceShow.jsx
@@ -420,14 +420,12 @@ class DeviceShow extends Component {
         />
 
         <Sidebar
-          backgroundColor={debugSidebarBackgroundColor}
           show={showDebugSidebar}
           toggle={this.handleToggleDebug}
           sidebarIcon={<BugOutlined />}
           iconBackground={debugSidebarBackgroundColor}
           iconPosition='top'
           message='Access Debug mode to view device packet transfer'
-          width={650}
         >
           <Debug
             deviceId={this.props.match.params.id}
@@ -444,8 +442,6 @@ class DeviceShow extends Component {
                 iconPosition='middle'
                 message='Send a manual downlink using an HTTP integration'
                 disabledMessage='Please attach a label with an HTTP integration to use Downlink'
-                backgroundColor={debugSidebarBackgroundColor}
-                width={650}
               >
                 <Downlink
                   src="DeviceShow"

--- a/assets/js/components/flows/FlowsWorkspace.jsx
+++ b/assets/js/components/flows/FlowsWorkspace.jsx
@@ -1,5 +1,13 @@
 import React, { useState, useRef, useEffect, Fragment } from 'react';
-import ReactFlow, { ReactFlowProvider, isNode, isEdge, removeElements, addEdge, getOutgoers } from 'react-flow-renderer';
+import ReactFlow, { 
+  ReactFlowProvider, 
+  isNode, 
+  isEdge, 
+  removeElements, 
+  addEdge, 
+  getOutgoers, 
+  useStoreActions 
+} from 'react-flow-renderer';
 import omit from 'lodash/omit'
 import FlowsSidebar from './FlowsSidebar'
 import FlowsSettingsBar from './FlowsSettingsBar'
@@ -8,7 +16,7 @@ import FunctionNode from './nodes/FunctionNode'
 import ChannelNode from './nodes/ChannelNode'
 import DebugNode from './nodes/DebugNode'
 import DeviceNode from './nodes/DeviceNode'
-import Sidebar from '../common/Sidebar';
+import InfoSidebar from './infoSidebar/InfoSidebar';
 import NodeInfo from './infoSidebar/NodeInfo';
 import analyticsLogger from '../../util/analyticsLogger'
 
@@ -157,19 +165,17 @@ export default ({ initialElementsMap, submitChanges, setChangesState, hasChanges
             submitChanges={() => submitChanges(elementsMap)}
           />
         </div>
+        <InfoSidebar
+          show={showInfoSidebar}
+          width={500}
+          toggle={handleToggleSidebar}
+        >
+          <NodeInfo 
+            id={selectedNodeId && selectedNodeId.split(/-(.+)/)[1]}
+            type={selectedNodeId && selectedNodeId.split(/-(.+)/)[0].replace('-', '')}
+          />
+        </InfoSidebar>
       </ReactFlowProvider>
-      <Sidebar
-        backgroundColor='white'
-        show={showInfoSidebar}
-        message='Information'
-        width={500}
-        toggle={handleToggleSidebar}
-      >
-        <NodeInfo 
-          id={selectedNodeId && selectedNodeId.split(/-(.+)/)[1]}
-          type={selectedNodeId && selectedNodeId.split(/-(.+)/)[0].replace('-', '')}
-        />
-      </Sidebar>
     </Fragment>
   );
 };

--- a/assets/js/components/flows/FlowsWorkspace.jsx
+++ b/assets/js/components/flows/FlowsWorkspace.jsx
@@ -1,12 +1,8 @@
-import React, { useState, useRef, useEffect, Fragment } from 'react';
+import React, { useState, useRef, Fragment } from 'react';
 import ReactFlow, { 
   ReactFlowProvider, 
   isNode, 
-  isEdge, 
-  removeElements, 
-  addEdge, 
-  getOutgoers, 
-  useStoreActions 
+  isEdge
 } from 'react-flow-renderer';
 import omit from 'lodash/omit'
 import FlowsSidebar from './FlowsSidebar'

--- a/assets/js/components/flows/infoSidebar/InfoSidebar.jsx
+++ b/assets/js/components/flows/infoSidebar/InfoSidebar.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { CloseOutlined } from '@ant-design/icons';
+import { Button } from 'antd';
+import { useStoreActions } from 'react-flow-renderer';
+
+export default ({ toggle, show, width, children }) => {
+  const setSelectedElements = useStoreActions((actions) => actions.setSelectedElements);
+
+  const handleToggle = () => {
+    toggle();
+    setSelectedElements([]);
+  }
+
+  return (
+    <div style={{
+      background: 'white',
+      position: 'absolute',
+      top: 55,
+      width: show ? width : 0,
+      height: 'calc(100vh - 55px)',
+      right: 0,
+      zIndex: show ? 10 : 1,
+      padding: 0,
+      transition: 'all 0.5s ease',
+      boxShadow: '10px 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19)'
+    }}>
+      <Button 
+        style={{ border: 'none', top: '35px', left: '35px' }} 
+        onClick={handleToggle} 
+        icon={<CloseOutlined style={{ fontSize: 30, color: '#D2DDE8' }} />}
+      />
+      {show && children}
+    </div>
+  );
+}


### PR DESCRIPTION
This PR:
- Extracts logic for info sidebar out of the main sidebar component (resetting the main component to match staging)
- Creates new component for info sidebar
- New info sidebar component uses internal action from React Flow to deselect nodes when we close the sidebar