### PR TITLE
Device flows fixes

### DIFF
--- a/assets/js/components/common/FlowsLayout.jsx
+++ b/assets/js/components/common/FlowsLayout.jsx
@@ -18,7 +18,7 @@ const nodeTypes = {
   deviceNode: DeviceNode
 };
 
-const createGraphLayout = (elements, nodeSizes) => {
+const getLayoutElements = (elements, nodeSizes) => {
   const DEFAULT_NODE_WIDTH = 300; // TODO reduce so that flow can be shorter + fix if node is wider than this
   const DEFAULT_NODE_HEIGHT = 30;
   const g = new dagre.graphlib.Graph({});
@@ -71,7 +71,7 @@ export default ({ elements }) => {
     }
   ));
 
-  const layoutedElements = createGraphLayout(elements, nodeSizes);
+  const layoutedElements = getLayoutElements(elements, nodeSizes);
   const [flowElements] = useState(layoutedElements);
 
   return (

--- a/assets/js/components/common/FlowsLayout.jsx
+++ b/assets/js/components/common/FlowsLayout.jsx
@@ -18,31 +18,29 @@ const nodeTypes = {
   deviceNode: DeviceNode
 };
 
-const dagreGraph = new dagre.graphlib.Graph();
-dagreGraph.setDefaultEdgeLabel(() => ({}));
-
-const getLayoutedElements = (elements, nodeSizes) => {
+const createGraphLayout = (elements, nodeSizes) => {
   const DEFAULT_NODE_WIDTH = 300; // TODO reduce so that flow can be shorter + fix if node is wider than this
   const DEFAULT_NODE_HEIGHT = 30;
-
-  dagreGraph.setGraph({ rankdir: 'LR' });
+  const g = new dagre.graphlib.Graph({});
+  g.setGraph({ rankdir: 'LR' });
+  g.setDefaultEdgeLabel(() => ({}));
 
   elements.forEach((el) => {
     if (isNode(el)) {
       const existingNode = find(nodeSizes, {id: el.id});
       let nodeWidth = existingNode ? existingNode.width : DEFAULT_NODE_WIDTH;
       let nodeHeight = existingNode ? existingNode.height : DEFAULT_NODE_HEIGHT;
-      dagreGraph.setNode(el.id, { width: nodeWidth, height: nodeHeight });
+      g.setNode(el.id, { width: nodeWidth, height: nodeHeight });
     } else {
-      dagreGraph.setEdge(el.source, el.target);
+      g.setEdge(el.source, el.target);
     }
   });
-
-  dagre.layout(dagreGraph);
+  
+  dagre.layout(g);
 
   return elements.map((el) => {
     if (isNode(el)) {
-      const nodeWithPosition = dagreGraph.node(el.id);
+      const nodeWithPosition = g.node(el.id);
       el.targetPosition = 'left';
       el.sourcePosition = 'right';
 
@@ -61,11 +59,11 @@ const getLayoutedElements = (elements, nodeSizes) => {
 
     return el;
   });
-};
+}
 
 export default ({ elements }) => {
-  const nodes = useStoreState((state) => state.nodes);
-  const nodeSizes = nodes.map(node => (
+  const nodeStates = useStoreState((state) => state.nodes);
+  const nodeSizes = nodeStates.map(node => (
     { 
       id: node.id,
       width: node.__rf.width,
@@ -73,8 +71,8 @@ export default ({ elements }) => {
     }
   ));
 
-  const layoutedElements = getLayoutedElements(elements, nodeSizes);
-  const [flowElements] = useState(layoutedElements); // prevents render loop
+  const layoutedElements = createGraphLayout(elements, nodeSizes);
+  const [flowElements] = useState(layoutedElements);
 
   return (
     <ReactFlow

--- a/assets/js/components/devices/DeviceFlows.jsx
+++ b/assets/js/components/devices/DeviceFlows.jsx
@@ -36,6 +36,8 @@ export default ({ deviceId }) => {
     }
     if (flow.device_id && !deviceIds.includes(flow.device_id)) {
       deviceIds.push(flow.device_id);
+    } else {
+      deviceIds.push(deviceId);
     }
     if (flow.label_id && !labelIds.includes(flow.label_id)) {
       labelIds.push(flow.label_id);
@@ -235,7 +237,7 @@ export default ({ deviceId }) => {
 
   return (
     <Card bodyStyle={{ padding: 0, paddingTop: 1, overflowX: 'scroll' }} title='Flows'>
-      <div style={{ padding: '20px', position: "relative", width: "1000px", height: `${85*flowsByDevice.length}px` }}>
+      <div style={{ padding: '20px', position: "relative", width: "1000px", height: `${85*(flowsByDevice.length || 50)}px` }}>
         <ReactFlowProvider>
           <FlowsLayout elements={elements} />
         </ReactFlowProvider>

--- a/assets/js/components/devices/DeviceFlows.jsx
+++ b/assets/js/components/devices/DeviceFlows.jsx
@@ -237,11 +237,13 @@ export default ({ deviceId }) => {
 
   return (
     <Card bodyStyle={{ padding: 0, paddingTop: 1, overflowX: 'scroll' }} title='Flows'>
+      {elements.length > 0 ?
       <div style={{ padding: '20px', position: "relative", width: "1000px", height: `${85*(flowsByDevice.length || 50)}px` }}>
         <ReactFlowProvider>
           <FlowsLayout elements={elements} />
         </ReactFlowProvider>
-      </div>
+      </div> 
+      : <div style={{ textAlign: 'center', padding: '20px 0', color: 'grey' }}>No flows exist for this device</div>}
     </Card>
   );
 }


### PR DESCRIPTION
- Fixes layout which was sometimes not rendering the nodes or rendering them in a weird order (theory is because the graph wasn't recreated on re-render)
- Shows text when no flows exist
- Fixes the device name not showing up when it's part of a flow w/ only label