### PR TITLE
Properly format event body in debug panel

### DIFF
--- a/lib/console_web/controllers/router/device_controller.ex
+++ b/lib/console_web/controllers/router/device_controller.ex
@@ -139,6 +139,13 @@ defmodule ConsoleWeb.Router.DeviceController do
         result =
           Ecto.Multi.new()
           |> Ecto.Multi.run(:event, fn _repo, _ ->
+            event = case event["data"]["req"]["body"] do
+              nil -> event
+              _ -> 
+                {:ok, decoded_body} = Poison.decode(event["data"]["req"]["body"])
+                Kernel.put_in(event["data"]["req"]["body"], decoded_body)
+            end
+
             Events.create_event(Map.put(event, "organization_id", organization.id))
           end)
           |> Ecto.Multi.run(:device, fn _repo, %{ event: event } ->
@@ -263,7 +270,7 @@ defmodule ConsoleWeb.Router.DeviceController do
     event = Map.merge(event, %{
       device_name: device.name
     })
-
+    
     event_to_publish =
       event
       |> Map.from_struct()

--- a/lib/console_web/controllers/router/device_controller.ex
+++ b/lib/console_web/controllers/router/device_controller.ex
@@ -270,7 +270,7 @@ defmodule ConsoleWeb.Router.DeviceController do
     event = Map.merge(event, %{
       device_name: device.name
     })
-    
+
     event_to_publish =
       event
       |> Map.from_struct()

--- a/test/console_web/controllers/device_controller_test.exs
+++ b/test/console_web/controllers/device_controller_test.exs
@@ -153,22 +153,5 @@ defmodule ConsoleWeb.DeviceControllerTest do
       assert Devices.get_device(device_1["id"]) == nil
       assert Devices.get_device(device_2["id"]) == nil
     end
-
-    test "debug device works properly", %{conn: conn} do
-      not_my_org = insert(:organization)
-      not_my_device = insert(:device, %{ organization_id: not_my_org.id })
-
-      assert_error_sent 404, fn ->
-        post conn, device_path(conn, :debug), %{ "device" => not_my_device.id}
-      end
-
-      resp_conn = post conn, device_path(conn, :create), %{
-        "device" => %{ "name" => "n", "dev_eui" => "aaaaaaaaaaaaaaa1", "app_eui" => "bbbbbbbbbbbbbbbb", "app_key" => "cccccccccccccccccccccccccccccccc" },
-        "label" => nil
-      }
-      device = json_response(resp_conn, 201)
-      resp_conn = post conn, device_path(conn, :debug), %{ "device" => device["id"]}
-      assert response(resp_conn, 204)
-    end
   end
 end


### PR DESCRIPTION
- properly format body before creating event
- remove old test that is no longer relevant (no more `debug` endpoint)

![image](https://user-images.githubusercontent.com/51131939/115464020-b1f4e280-a1e9-11eb-986e-3d39be53b079.png)

passing tests
```
..................................................

Finished in 1.9 seconds
50 tests, 0 failures
```