### PR TITLE
Create alert from side panel and apply to selected node

### DIFF
--- a/assets/js/actions/alert.js
+++ b/assets/js/actions/alert.js
@@ -5,8 +5,7 @@ export const createAlert = (alert) => {
 
     return rest.post('/api/alerts', {
         alert: alert
-      })
-      .then(response => {})
+      });
   }
 }
 

--- a/assets/js/actions/apollo.js
+++ b/assets/js/actions/apollo.js
@@ -115,6 +115,9 @@ const createApolloClient = (link) => (
             },
             alertsForNode: {
               merge: false
+            },
+            allAlerts: {
+              merge: false
             }
           },
         },

--- a/assets/js/components/alerts/AlertForm.jsx
+++ b/assets/js/components/alerts/AlertForm.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { Button, Row, Col, Input } from 'antd';
+import { Button, Row, Col } from 'antd';
 import { ArrowLeftOutlined, PlusOutlined, EditOutlined } from '@ant-design/icons';
 import AddDeviceAlertIcon from '../../../img/alerts/device-group-alert-add-icon.svg';
 import AddFunctionAlertIcon from '../../../img/alerts/function-alert-add-icon.svg';
@@ -8,28 +8,21 @@ import AddIntegrationAlertIcon from '../../../img/alerts/channel-alert-add-icon.
 import Text from 'antd/lib/typography/Text';
 import { useDispatch } from "react-redux";
 import { createAlert, updateAlert } from '../../actions/alert';
-import { Tabs } from 'antd';
-const { TabPane } = Tabs;
-import { DEFAULT_SETTINGS, ALERT_TYPES } from './constants';
-import AlertSetting from './AlertSetting';
+import AlertSettings from './AlertSettings';
 import { ALERT_SHOW } from '../../graphql/alerts';
 import { useQuery } from '@apollo/client';
 import { SkeletonLayout } from '../common/SkeletonLayout';
 import DeleteAlertModal from './DeleteAlertModal';
 
 export default (props) => {
-  const [name, setName] = useState('');
-  const [emailConfig, setEmailConfig] = useState({});
-  const [webhookConfig, setWebhookConfig] = useState({});
   const [showDeleteAlertModal, setShowDeleteAlertModal] = useState(false);
-  const [_tab, setTab] = useState('email');
   const dispatch = useDispatch();
-  const [alertData, setAlertData] = useState({});
   const { loading, error, data, refetch } = useQuery(ALERT_SHOW, {
     variables: { id: props.id },
     skip: !props.id
   });
   const socket = useSelector(state => state.apollo.socket);
+  const alertType = props.show && data && data.alert ? data.alert.node_type : props.alertType;
 
   useEffect(() => {
     if (props.show) {
@@ -44,28 +37,14 @@ export default (props) => {
       // executed when unmounted
       return () => {
         alertShowChannel.leave();
-    }
+      }
     }
   }, []);
-  
-  useEffect(() => {
-    if (!loading && !error && data) {
-      const parsedConfig = JSON.parse(data.alert.config);
-      setAlertData({
-        node_type: data.alert.node_type,
-        config: parsedConfig,
-        name: data.alert.name
-      });
-      if (parsedConfig.email) setEmailConfig(parsedConfig.email);
-      if (parsedConfig.webhook) setWebhookConfig(parsedConfig.webhook);
-    }
-  }, [data]);
 
   if (loading) return <SkeletonLayout />;
   if (error) return <Text>Data failed to load, please reload the page and try again</Text>;
 
   const renderIcon = () => {
-    const alertType = props.show ? alertData.node_type : props.alertType;
     const ICONS = {
       'device/group': AddDeviceAlertIcon,
       'function': AddFunctionAlertIcon,
@@ -84,7 +63,6 @@ export default (props) => {
   }
 
   const renderTitle = () => {
-    const alertType = props.show ? alertData.node_type : props.alertType;
     const TITLES = props.show ? {
       'device/group': 'Device/Group Alert Settings',
       'function': 'Function Alert Settings',
@@ -98,117 +76,15 @@ export default (props) => {
     return TITLES[alertType];
   }
 
-  const renderForm = () => {
-    const alertType = props.show ? alertData.node_type : props.alertType;
-    return (
-      <Tabs defaultActiveKey="email" size="large" centered onTabClick={tab => setTab(tab)}>
-        <TabPane tab="Email" key="email">
-          {alertType && DEFAULT_SETTINGS[alertType].map(s => (
-            <AlertSetting
-              key={`setting-email-${s.key}`}
-              eventKey={s.key}
-              eventDescription={s.description}
-              hasValue={s.hasValue}
-              type='email'
-              value={props.show && alertData.config.email[s.key]}
-              onChange={settings => {
-                if (settings.checked) {
-                  setEmailConfig({
-                    ...emailConfig,
-                    [settings.key]: {
-                      recipient: settings.recipient,
-                      ...('value' in settings && { value: settings.value })
-                    }
-                  });
-                } else {
-                  if (settings.key in emailConfig) {
-                    setEmailConfig({
-                      ...emailConfig,
-                      [settings.key]: undefined
-                    });
-                  }
-                }
-              }}
-            />
-          ))}
-        </TabPane>
-        <TabPane tab="Webhooks" key="webhooks">
-          {alertType && DEFAULT_SETTINGS[alertType].map(s => (
-            <AlertSetting
-              key={`setting-webhook-${s.key}`}
-              eventKey={s.key}
-              eventDescription={s.description}
-              hasValue={s.hasValue}
-              type='webhook'
-              onChange={settings => {
-                if (settings.checked) {
-                  setWebhookConfig({
-                    ...webhookConfig,
-                    [settings.key]: {
-                      url: settings.url,
-                      notes: settings.notes,
-                      ...('value' in settings && { value: settings.value })
-                    }
-                  });
-                } else {
-                  if (settings.key in webhookConfig) {
-                    setWebhookConfig({
-                      ...webhookConfig,
-                      [settings.key]: undefined
-                    });
-                  }
-                }
-              }}
-            />
-          ))}
-        </TabPane>
-      </Tabs>
-    );
-  }
-
-  const renderButton = () => {
-    const alertType = props.show ? alertData.node_type : props.alertType;
-
-    return (
-      <Button
-        icon={props.show ? <EditOutlined /> : <PlusOutlined />}
-        type="primary"
-        style={{ borderColor: alertType && ALERT_TYPES[alertType].color, backgroundColor: alertType && ALERT_TYPES[alertType].color, borderRadius: 50, text: 'white' }}
-        onClick={() => {
-          if (props.show) {
-            dispatch(updateAlert(props.id, {
-              ...name && { name },
-              config: {
-                ...(emailConfig && { email: emailConfig }),
-                ...(webhookConfig && { webhook: webhookConfig })
-              }
-            }));
-          } else {
-            dispatch(createAlert({
-              name: name,
-              config: {
-                ...(emailConfig && { email: emailConfig }),
-                ...(webhookConfig && { webhook: webhookConfig })
-              },
-              node_type: props.alertType
-            })).then(_ => {
-              props.backToAll();
-            });
-          }
-        }}
-      >
-        {`${props.show ? 'Update' : 'Create'} ${alertType && ALERT_TYPES[alertType].name} Alert`}
-      </Button>
-    );
-  }
-
   return (
     <React.Fragment>
       <div style={{ padding: '30px 30px 20px 30px' }}>
         <Button icon={<ArrowLeftOutlined />} style={{ border: 'none' }} onClick={props.back}>Back</Button>
-        <div style={{ float: 'right', padding: '0px 100px' }}>
-          <Button size="middle" type="danger" style={{ borderRadius: 5 }} onClick={openDeleteAlertModal}>Delete</Button>
+        {props.show && (
+          <div style={{ float: 'right', padding: '0px 100px' }}>
+            <Button size="middle" type="danger" style={{ borderRadius: 5 }} onClick={openDeleteAlertModal}>Delete</Button>
           </div>
+        )}
         <Row style={{ marginTop: '10px' }}>
           <Col span={10} style={{ padding: '70px 80px' }}>
             <img src={renderIcon()} />
@@ -219,27 +95,43 @@ export default (props) => {
             </div>
           </Col>
           <Col span={12} style={{ padding: '40px 20px'}}>
-            <Text style={{ fontSize: '16px' }} strong>Alert Name</Text>
-            <Input
-              onChange={e => { setName(e.target.value) }}
-              value={name}
-              placeholder={props.show ? alertData.name : 'e.g. Master Alert'}
-              suffix={`${name.length}/25`} 
-              maxLength={25}
+            <AlertSettings
+              alertType={alertType}
+              save={(name, emailConfig, webhookConfig) => {
+                if (props.show) {
+                  dispatch(updateAlert(props.id, {
+                    ...name && { name },
+                    config: {
+                      ...(emailConfig && { email: emailConfig }),
+                      ...(webhookConfig && { webhook: webhookConfig })
+                    }
+                  }));
+                } else {
+                  dispatch(createAlert({
+                    name: name,
+                    config: {
+                      ...(emailConfig && { email: emailConfig }),
+                      ...(webhookConfig && { webhook: webhookConfig })
+                    },
+                    node_type: props.alertType
+                  })).then(_ => {
+                    props.backToAll();
+                  });
+                }
+              }}
+              saveText={props.show ? 'Update' : 'Create'}
+              saveIcon={props.show ? <EditOutlined /> : <PlusOutlined />}
+              data={data}
+              show={props.show}
             />
-            <div style={{ marginTop: 20 }}>
-              {renderForm()}
-            </div>
-            <div style={{ marginTop: 20 }}>
-              {renderButton()}
-            </div>
           </Col>
         </Row>
       </div>
       <DeleteAlertModal
         open={showDeleteAlertModal}
-        alert={{ ...alertData, id: props.id}}
+        alert={{ id: props.id, ...(data && { ...data.alert })}}
         close={closeDeleteAlertModal}
+        cancel={() => { setShowDeleteAlertModal(false) }}
       />
     </React.Fragment>
   );

--- a/assets/js/components/alerts/AlertSetting.jsx
+++ b/assets/js/components/alerts/AlertSetting.jsx
@@ -42,12 +42,12 @@ export default (props) => {
 
   const timeMenu = () => (
     <Menu onClick={e => { setValue(e.key) }}>
-      <Menu.Item key="15">15 mins</Menu.Item>
-      <Menu.Item key="30">30 mins</Menu.Item>
-      <Menu.Item key="60">1 hr</Menu.Item>
-      <Menu.Item key="360">6 hrs</Menu.Item>
-      <Menu.Item key="540">9 hrs</Menu.Item>
-      <Menu.Item key="1440">24 hrs</Menu.Item>
+      <Menu.Item key={15}>15 mins</Menu.Item>
+      <Menu.Item key={30}>30 mins</Menu.Item>
+      <Menu.Item key={60}>1 hr</Menu.Item>
+      <Menu.Item key={360}>6 hrs</Menu.Item>
+      <Menu.Item key={540}>9 hrs</Menu.Item>
+      <Menu.Item key={1440}>24 hrs</Menu.Item>
     </Menu>
   );
 

--- a/assets/js/components/alerts/AlertSettings.jsx
+++ b/assets/js/components/alerts/AlertSettings.jsx
@@ -1,0 +1,139 @@
+import React, { Fragment, useState, useEffect } from 'react';
+import { Button, Input } from 'antd';
+import Text from 'antd/lib/typography/Text';
+import { Tabs } from 'antd';
+const { TabPane } = Tabs;
+import { DEFAULT_SETTINGS, ALERT_TYPES } from './constants';
+import AlertSetting from './AlertSetting';
+
+export default ({ alertType, save, saveText, cancel, back, saveIcon, show, data }) => {
+  const [name, setName] = useState('');
+  const [emailConfig, setEmailConfig] = useState({});
+  const [webhookConfig, setWebhookConfig] = useState({});
+  const [alertData, setAlertData] = useState({});
+
+  useEffect(() => {
+    if (show && data) {
+      const parsedConfig = JSON.parse(data.alert.config);
+      setAlertData({
+        node_type: data.alert.node_type,
+        config: parsedConfig,
+        name: data.alert.name
+      });
+      if (parsedConfig.email) setEmailConfig(parsedConfig.email);
+      if (parsedConfig.webhook) setWebhookConfig(parsedConfig.webhook);
+    }
+  }, [data]);
+
+  const renderForm = () => {
+    return (
+      <Tabs defaultActiveKey="email" size="large" centered>
+        <TabPane tab="Email" key="email">
+          {alertType && DEFAULT_SETTINGS[alertType].map(s => (
+            <AlertSetting
+              key={`setting-email-${s.key}`}
+              eventKey={s.key}
+              eventDescription={s.description}
+              hasValue={s.hasValue}
+              type='email'
+              value={show && alertData && alertData.config && alertData.config.email[s.key]}
+              onChange={settings => {
+                if (settings.checked) {
+                  setEmailConfig({
+                    ...emailConfig,
+                    [settings.key]: {
+                      recipient: settings.recipient,
+                      ...('value' in settings && { value: settings.value })
+                    }
+                  });
+                } else {
+                  if (settings.key in emailConfig) {
+                    setEmailConfig({
+                      ...emailConfig,
+                      [settings.key]: undefined
+                    });
+                  }
+                }
+              }}
+            />
+          ))}
+        </TabPane>
+        <TabPane tab="Webhooks" key="webhooks">
+          {alertType && DEFAULT_SETTINGS[alertType].map(s => (
+            <AlertSetting
+              key={`setting-webhook-${s.key}`}
+              eventKey={s.key}
+              eventDescription={s.description}
+              hasValue={s.hasValue}
+              type='webhook'
+              value={show && alertData && alertData.config && alertData.config.webhook[s.key]}
+              onChange={settings => {
+                if (settings.checked) {
+                  setWebhookConfig({
+                    ...webhookConfig,
+                    [settings.key]: {
+                      url: settings.url,
+                      notes: settings.notes,
+                      ...('value' in settings && { value: settings.value })
+                    }
+                  });
+                } else {
+                  if (settings.key in webhookConfig) {
+                    setWebhookConfig({
+                      ...webhookConfig,
+                      [settings.key]: undefined
+                    });
+                  }
+                }
+              }}
+            />
+          ))}
+        </TabPane>
+      </Tabs>
+    );
+  }
+
+  const renderButton = () => {
+    return (
+      <Button
+        icon={saveIcon}
+        type="primary"
+        style={{ borderColor: alertType && ALERT_TYPES[alertType].color, backgroundColor: alertType && ALERT_TYPES[alertType].color, borderRadius: 50, text: 'white' }}
+        onClick={() => {
+          save(name, emailConfig, webhookConfig);
+        }}
+      >
+        {`${saveText} ${alertType && ALERT_TYPES[alertType].name} Alert`}
+      </Button>
+    );
+  }
+
+  return(
+    <Fragment>
+      <Text style={{ fontSize: '16px' }} strong>Alert Name</Text>
+      <Input
+        onChange={e => { setName(e.target.value) }}
+        value={name}
+        placeholder={show ? alertData.name : 'e.g. Master Alert'}
+        suffix={`${name.length}/25`} 
+        maxLength={25}
+      />
+      <div style={{ marginTop: 20 }}>
+        {renderForm()}
+      </div>
+      <div style={{ marginTop: 20 }}>
+        {renderButton()}
+        {
+          cancel && (
+            <Button
+              style={{ marginLeft: 10, borderRadius: 50}}
+              onClick={() => { back() }}
+            >
+              Cancel
+            </Button>
+          )
+        }
+      </div>
+    </Fragment>
+  );
+}

--- a/assets/js/components/flows/infoSidebar/AlertNodeSettings.jsx
+++ b/assets/js/components/flows/infoSidebar/AlertNodeSettings.jsx
@@ -9,6 +9,7 @@ import { SkeletonLayout } from '../../common/SkeletonLayout';
 import { Link } from 'react-router-dom';
 import { addAlertToNode, removeAlertFromNode } from '../../../actions/alert';
 import { useDispatch } from "react-redux";
+import NewAlertWithNode from './NewAlertWithNode';
 
 export default (props) => {
   const { loading, error, data, refetch } = useQuery(ALERTS_PER_TYPE, {
@@ -28,6 +29,7 @@ export default (props) => {
   const nodeAlertsChannels = socket.channel("graphql:alert_settings_table", {});
   const currentOrganizationId = useSelector(state => state.organization.currentOrganizationId);
   const dispatch = useDispatch();
+  const [showNew, setShowNew] = useState(false);
 
   useEffect(() => {
     // executed when mounted
@@ -58,12 +60,12 @@ export default (props) => {
   if (loading || alertsForNodeLoading) return(<div><SkeletonLayout /></div>);
   if (error || alertsForNodeError) return(<div><Text>Data failed to load, please reload the page and try again</Text></div>);
 
-  return (
+  const renderAllAlerts = () => (
     <div>
       <Button
         icon={<BellOutlined />}
         style={{ borderRadius: 4 }}
-        onClick={() => {}}
+        onClick={() => { setShowNew(true) }}
       >
         Create New Alert
       </Button>
@@ -101,5 +103,12 @@ export default (props) => {
         ]}
       />
     </div>
+  )
+  
+  return(
+    <React.Fragment>
+      { !showNew && renderAllAlerts() }
+      { showNew && <NewAlertWithNode nodeId={props.nodeId} nodeType={props.type} back={() => { setShowNew(false)}} /> }
+    </React.Fragment>
   );
 }

--- a/assets/js/components/flows/infoSidebar/NewAlertWithNode.jsx
+++ b/assets/js/components/flows/infoSidebar/NewAlertWithNode.jsx
@@ -1,0 +1,37 @@
+import React, { Fragment } from 'react';
+import { PlusOutlined } from '@ant-design/icons';
+import Text from 'antd/lib/typography/Text';
+import { useDispatch } from "react-redux";
+import { createAlert, addAlertToNode } from '../../../actions/alert';
+import AlertSettings from '../../alerts/AlertSettings';
+
+export default (props) => {
+  const dispatch = useDispatch();
+  const alertType = ['device', 'group'].includes(props.nodeType) ? 'device/group' : props.nodeType;
+
+  return (
+    <Fragment>
+      <Text style={{ display: 'block', fontSize: '20px', marginBottom: 5 }} strong>Create New Alert</Text>
+      <AlertSettings
+        alertType={alertType}
+        save={(name, emailConfig, webhookConfig) => {
+          dispatch(createAlert({
+            name: name,
+            config: {
+              ...(emailConfig && { email: emailConfig }),
+              ...(webhookConfig && { webhook: webhookConfig })
+            },
+            node_type: alertType
+          })).then(data => {
+            dispatch(addAlertToNode(data.data.id, props.nodeId, props.nodeType));
+            props.back();
+          });
+        }}
+        saveText="Create"
+        back={props.back}
+        saveIcon={<PlusOutlined />}
+        cancel
+      />
+    </Fragment>
+  );
+}


### PR DESCRIPTION
To test: open a node side panel, go to alerts, create new alert, see alert get created and applied to node.

This PR refactors the settings component from the alert form to be reusable for side panel create new alert settings as well.