### PR TITLE
Alerts changes to config + changeset checks

### DIFF
--- a/assets/js/components/alerts/AlertForm.jsx
+++ b/assets/js/components/alerts/AlertForm.jsx
@@ -99,22 +99,16 @@ export default (props) => {
           <Col span={12} style={{ padding: '40px 20px'}}>
             <AlertSettings
               alertType={alertType}
-              save={(name, emailConfig, webhookConfig) => {
+              save={(name, config) => {
                 if (props.show) {
                   dispatch(updateAlert(props.id, {
                     ...name && { name },
-                    config: {
-                      ...(emailConfig && { email: emailConfig }),
-                      ...(webhookConfig && { webhook: webhookConfig })
-                    }
+                    config
                   }));
                 } else {
                   dispatch(createAlert({
                     name: name,
-                    config: {
-                      ...(emailConfig && { email: emailConfig }),
-                      ...(webhookConfig && { webhook: webhookConfig })
-                    },
+                    config,
                     node_type: props.alertType
                   })).then(_ => {
                     history.push('/alerts');

--- a/assets/js/components/alerts/AlertSettings.jsx
+++ b/assets/js/components/alerts/AlertSettings.jsx
@@ -8,8 +8,7 @@ import AlertSetting from './AlertSetting';
 
 export default ({ alertType, save, saveText, cancel, back, saveIcon, show, data }) => {
   const [name, setName] = useState('');
-  const [emailConfig, setEmailConfig] = useState({});
-  const [webhookConfig, setWebhookConfig] = useState({});
+  const [config, setConfig] = useState({});
   const [alertData, setAlertData] = useState({});
 
   useEffect(() => {
@@ -20,8 +19,7 @@ export default ({ alertType, save, saveText, cancel, back, saveIcon, show, data 
         config: parsedConfig,
         name: data.alert.name
       });
-      if (parsedConfig.email) setEmailConfig(parsedConfig.email);
-      if (parsedConfig.webhook) setWebhookConfig(parsedConfig.webhook);
+      setConfig(parsedConfig);
     }
   }, [data]);
 
@@ -29,65 +27,103 @@ export default ({ alertType, save, saveText, cancel, back, saveIcon, show, data 
     return (
       <Tabs defaultActiveKey="email" size="large" centered>
         <TabPane tab="Email" key="email">
-          {alertType && DEFAULT_SETTINGS[alertType].map(s => (
-            <AlertSetting
-              key={`setting-email-${s.key}`}
-              eventKey={s.key}
-              eventDescription={s.description}
-              hasValue={s.hasValue}
-              type='email'
-              value={show && alertData && alertData.config && alertData.config.email[s.key]}
-              onChange={settings => {
-                if (settings.checked) {
-                  setEmailConfig({
-                    ...emailConfig,
-                    [settings.key]: {
-                      recipient: settings.recipient,
-                      ...('value' in settings && { value: settings.value })
-                    }
-                  });
-                } else {
-                  if (settings.key in emailConfig) {
-                    setEmailConfig({
-                      ...emailConfig,
-                      [settings.key]: undefined
-                    });
-                  }
+          {alertType &&
+            DEFAULT_SETTINGS[alertType].map((s) => (
+              <AlertSetting
+                key={`setting-email-${s.key}`}
+                eventKey={s.key}
+                eventDescription={s.description}
+                hasValue={s.hasValue}
+                type="email"
+                value={
+                  show &&
+                  alertData &&
+                  alertData.config &&
+                  alertData.config[s.key] &&
+                  alertData.config[s.key].email
                 }
-              }}
-            />
-          ))}
+                onChange={(settings) => {
+                  if (settings.checked) {
+                    setConfig({
+                      ...config,
+                      [settings.key]: {
+                        ...(config[settings.key] &&
+                          "webhook" in config[settings.key] && {
+                            webhook: config[settings.key].webhook,
+                          }),
+                        email: {
+                          recipient: settings.recipient,
+                          ...("value" in settings && { value: settings.value }),
+                        },
+                      },
+                    });
+                  } else {
+                    if (settings.key in config) {
+                      setConfig({
+                        ...config,
+                        [settings.key]: {
+                          ...(config[settings.key] &&
+                            "webhook" in config[settings.key] && {
+                              webhook: config[settings.key].webhook,
+                            }),
+                          email: undefined,
+                        },
+                      });
+                    }
+                  }
+                }}
+              />
+            ))}
         </TabPane>
         <TabPane tab="Webhooks" key="webhooks">
-          {alertType && DEFAULT_SETTINGS[alertType].map(s => (
-            <AlertSetting
-              key={`setting-webhook-${s.key}`}
-              eventKey={s.key}
-              eventDescription={s.description}
-              hasValue={s.hasValue}
-              type='webhook'
-              value={show && alertData && alertData.config && alertData.config.webhook[s.key]}
-              onChange={settings => {
-                if (settings.checked) {
-                  setWebhookConfig({
-                    ...webhookConfig,
-                    [settings.key]: {
-                      url: settings.url,
-                      notes: settings.notes,
-                      ...('value' in settings && { value: settings.value })
-                    }
-                  });
-                } else {
-                  if (settings.key in webhookConfig) {
-                    setWebhookConfig({
-                      ...webhookConfig,
-                      [settings.key]: undefined
-                    });
-                  }
+          {alertType &&
+            DEFAULT_SETTINGS[alertType].map((s) => (
+              <AlertSetting
+                key={`setting-webhook-${s.key}`}
+                eventKey={s.key}
+                eventDescription={s.description}
+                hasValue={s.hasValue}
+                type="webhook"
+                value={
+                  show &&
+                  alertData &&
+                  alertData.config &&
+                  alertData.config[s.key] &&
+                  alertData.config[s.key].webhook
                 }
-              }}
-            />
-          ))}
+                onChange={(settings) => {
+                  if (settings.checked) {
+                    setConfig({
+                      ...config,
+                      [settings.key]: {
+                        ...(config[settings.key] &&
+                          "email" in config[settings.key] && {
+                            email: config[settings.key].email,
+                          }),
+                        webhook: {
+                          url: settings.url,
+                          notes: settings.notes,
+                          ...("value" in settings && { value: settings.value }),
+                        },
+                      },
+                    });
+                  } else {
+                    if (settings.key in config) {
+                      setConfig({
+                        ...config,
+                        [settings.key]: {
+                          ...(config[settings.key] &&
+                            "email" in config[settings.key] && {
+                              email: config[settings.key].email,
+                            }),
+                          webhook: undefined,
+                        },
+                      });
+                    }
+                  }
+                }}
+              />
+            ))}
         </TabPane>
       </Tabs>
     );
@@ -100,7 +136,7 @@ export default ({ alertType, save, saveText, cancel, back, saveIcon, show, data 
         type="primary"
         style={{ borderColor: alertType && ALERT_TYPES[alertType].color, backgroundColor: alertType && ALERT_TYPES[alertType].color, borderRadius: 50, text: 'white' }}
         onClick={() => {
-          save(name, emailConfig, webhookConfig);
+          save(name, config);
         }}
       >
         {`${saveText} ${alertType && ALERT_TYPES[alertType].name} Alert`}

--- a/lib/console/alerts/alert.ex
+++ b/lib/console/alerts/alert.ex
@@ -2,6 +2,8 @@ defmodule Console.Alerts.Alert do
   use Ecto.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
+  alias Console.Helpers
+  alias Console.Organizations.Organization
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -18,22 +20,77 @@ defmodule Console.Alerts.Alert do
   end
 
   def changeset(alert, attrs) do
+    config = Helpers.drop_keys_with_empty_map(attrs["config"])
+    attrs = Map.put(attrs, "config", Map.new(config))
+
     alert
     |> cast(attrs, [:name, :organization_id, :last_triggered_at, :config, :node_type])
     |> validate_required([:organization_id, :config, :node_type])
     |> validate_required(:name, message: "Name cannot be blank")
     |> validate_length(:name, max: 50, message: "Name cannot be longer than 50 characters")
     |> check_config_not_empty
+    |> check_webhook_config_url
+    |> check_valid_event_key
   end
 
   defp check_config_not_empty(changeset) do
     case changeset do
       %Ecto.Changeset{valid?: true, changes: %{config: config}} ->
-        valid_config = config != %{"email" => %{}, "webhook" => %{}}
+        empty_config = 
+          case config do
+            map when map == %{} -> true # must use guard since %{} matches any map
+            _ -> false
+        end
 
-        case valid_config do
-          false -> add_error(changeset, :message, "Alert must have at least one email or webhook setting turned on")
-          true -> changeset
+        case empty_config do
+          true -> add_error(changeset, :message, "Alert must have at least one email or webhook setting turned on")
+          false -> changeset
+        end
+      _ -> changeset
+    end
+  end
+
+  defp check_webhook_config_url(changeset) do
+    case changeset do
+      %Ecto.Changeset{valid?: true, changes: %{config: config}} ->
+        missing_url = Enum.any?(config, fn alert_event_config ->
+          {_event_key, event_config} = alert_event_config
+          if Map.has_key?(event_config, "webhook") do
+            event_config["webhook"]["url"] != "" || event_config["webhook"]["url"] != nil
+          else
+            false
+          end
+        end)
+
+        case missing_url do
+          true -> add_error(changeset, :message, "Alert webhook must have URL")
+          false -> changeset
+        end
+      _ -> changeset
+    end
+  end
+
+  defp check_valid_event_key(changeset) do
+    case changeset do
+      %Ecto.Changeset{valid?: true, changes: %{config: config}} ->
+        invalid_config = Enum.any?(config, fn alert_event_config ->
+          {event_key, _event_config} = alert_event_config
+          
+          Enum.member?([
+            "device_deleted",
+            "device_join_otaa_first_time",
+            "device_stops_transmitting",
+            "integration_stops_working",
+            "integration_receives_first_event",
+            "downlink_unsuccessful",
+            "integration_with_devices_deleted",
+            "integration_with_devices_updated"
+          ], event_key) != true
+        end)
+
+        case invalid_config do
+          true -> add_error(changeset, :message, "Alert must have a valid event key")
+          false -> changeset
         end
       _ -> changeset
     end

--- a/lib/console/helpers/helpers.ex
+++ b/lib/console/helpers/helpers.ex
@@ -35,4 +35,11 @@ defmodule Console.Helpers do
   def check_special_characters(string) do
     String.match?(string, ~r/^[A-Za-z0-9\(\)\[\]\-\_\+\|\!\?\:\s]+$/)
   end
+
+  def drop_keys_with_empty_map(map) do
+    Enum.filter(map, fn i ->
+      {key, value} = i
+      value != %{}
+    end)
+  end
 end

--- a/lib/console_web/controllers/alert_controller.ex
+++ b/lib/console_web/controllers/alert_controller.ex
@@ -1,7 +1,6 @@
 defmodule ConsoleWeb.AlertController do
   use ConsoleWeb, :controller
 
-  alias Console.Repo
   alias Console.Alerts
   alias Console.Alerts.Alert
   alias Console.Alerts.AlertNodes


### PR DESCRIPTION
Previously, an alert's `config` would look like:
```
{
...
config: {
  "email": {
    "device_deleted": {
       recipient: "admin"
    },
   "downlink_unsuccessful": {
        recipient: "all"
     }
   },
    "webhook": {
       "device_deleted": {
          url: "http://hello.com",
          notes: "hello"
      }
  }
}
```

This PR changes it to be:
```
{
...
config: {
  "device_deleted": {
      "email": {
          recipient: "admin"
  },
      "webhook": {
          url: "http://hello.com",
          notes: "hello"
      }
  },
  "downlink_unsuccessful": {
      "email": {
          recipient: "all"
      }
    }
  }
}
```

so that it is easier to query when checking if `alert_event` needs to be added by using the event key, i.e. `select config -> 'downlink_unsuccessful' as downlink_unsuccessful from alerts;` 

This PR also adds a check to make sure URL is present for webhook types and that the event key is valid to prevent bad data.