### PR TITLE
Update payload verification of invalid unicode characters

### DIFF
--- a/lib/console_web/controllers/router/device_controller.ex
+++ b/lib/console_web/controllers/router/device_controller.ex
@@ -151,9 +151,10 @@ defmodule ConsoleWeb.Router.DeviceController do
             event = case event["data"]["payload"] do
               nil -> event
               _ ->
-                case :unicode.characters_to_binary(event["data"]["payload"]) |> String.at(0) do
-                  <<0>> -> Kernel.put_in(event["data"]["payload"], "Unsupported unicode escape sequence in payload")
-                  _ -> event
+                if String.contains?(event["data"]["payload"], <<0>>) or String.contains?(event["data"]["payload"], <<1>>) do
+                  Kernel.put_in(event["data"]["payload"], "Unsupported unicode escape sequence in payload")
+                else
+                  event
                 end
             end
 


### PR DESCRIPTION
instead of only checking for first character, check each character in payload to make sure invalid unicode characters aren't present