### PR TITLE
Remove function alerts

### DIFF
--- a/assets/js/components/alerts/AlertForm.jsx
+++ b/assets/js/components/alerts/AlertForm.jsx
@@ -7,7 +7,6 @@ import {
   EditOutlined,
 } from "@ant-design/icons";
 import AddDeviceAlertIcon from "../../../img/alerts/device-label-alert-add-icon.svg";
-import AddFunctionAlertIcon from "../../../img/alerts/function-alert-add-icon.svg";
 import AddIntegrationAlertIcon from "../../../img/alerts/channel-alert-add-icon.svg";
 import Text from "antd/lib/typography/Text";
 import { useDispatch } from "react-redux";
@@ -60,7 +59,6 @@ export default (props) => {
   const renderIcon = () => {
     const ICONS = {
       "device/label": AddDeviceAlertIcon,
-      function: AddFunctionAlertIcon,
       integration: AddIntegrationAlertIcon,
     };
     return ICONS[alertType];
@@ -79,12 +77,10 @@ export default (props) => {
     const TITLES = props.show
       ? {
           "device/label": "Device/Label Alert Settings",
-          function: "Function Alert Settings",
           integration: "Integration Alert Settings",
         }
       : {
           "device/Label": "New Device/Label Alert",
-          function: "New Function Alert",
           integration: "New Integration Alert",
         };
 
@@ -129,8 +125,8 @@ export default (props) => {
             </h1>
             <div>
               <p style={{ fontSize: "16px" }}>
-                Alerts can be created for Device/Label Nodes, Function Nodes or
-                Integration Nodes.
+                Alerts can be created for Device/Label Nodes or Integration
+                Nodes.
               </p>
               <p>
                 <a>Learn more about alerts</a>

--- a/assets/js/components/alerts/AlertIndexTable.jsx
+++ b/assets/js/components/alerts/AlertIndexTable.jsx
@@ -3,7 +3,6 @@ import { Link } from "react-router-dom";
 import { Table, Button } from "antd";
 import Text from "antd/lib/typography/Text";
 import DeviceLabelTriggerIcon from "../../../img/alerts/alert-trigger-device-label.svg";
-import FunctionTriggerIcon from "../../../img/alerts/alert-trigger-function.svg";
 import IntegrationTriggerIcon from "../../../img/alerts/alert-trigger-integration.svg";
 import moment from "moment";
 import { DeleteOutlined } from "@ant-design/icons";
@@ -21,16 +20,6 @@ export default (props) => {
               style={{ height: 20, marginRight: 5 }}
             />
             Device/Label
-          </span>
-        );
-      case "function":
-        return (
-          <span>
-            <img
-              src={FunctionTriggerIcon}
-              style={{ height: 20, marginRight: 5 }}
-            />
-            Function
           </span>
         );
       case "integration":

--- a/assets/js/components/alerts/AlertsIndex.jsx
+++ b/assets/js/components/alerts/AlertsIndex.jsx
@@ -124,11 +124,18 @@ export default (props) => {
                 style={{ padding: "10px 60px 1px 60px", margin: "10px 0px" }}
               >
                 <p style={{ fontSize: "16px", color: "#565656" }}>
-                  Alerts can be created for Device/Label Nodes, Function Nodes
-                  or Integration Nodes.
+                  Alerts can be created for
+                  <br />
+                  Device/Label Nodes or Integration Nodes.
                 </p>
               </div>
-              <div style={{ flexDirection: "row", display: "flex" }}>
+              <div
+                style={{
+                  flexDirection: "row",
+                  display: "flex",
+                  justifyContent: "center",
+                }}
+              >
                 <AlertTypeButton
                   backgroundColor="#2C79EE"
                   onClick={() => {
@@ -136,14 +143,6 @@ export default (props) => {
                   }}
                 >
                   Device/Label Alert
-                </AlertTypeButton>
-                <AlertTypeButton
-                  backgroundColor="#9F59F7"
-                  onClick={() => {
-                    setAlertType("function");
-                  }}
-                >
-                  Function Alert
                 </AlertTypeButton>
                 <AlertTypeButton
                   backgroundColor="#12CB9E"

--- a/assets/js/components/alerts/constants.js
+++ b/assets/js/components/alerts/constants.js
@@ -71,10 +71,6 @@ export const ALERT_TYPES = {
     name: "Device/Label",
     color: "#2C79EE",
   },
-  function: {
-    name: "Function",
-    color: "#9F59F7",
-  },
   integration: {
     name: "Integration",
     color: "#12CB9E",

--- a/lib/console/alerts/alert.ex
+++ b/lib/console/alerts/alert.ex
@@ -141,7 +141,6 @@ defmodule Console.Alerts.Alert do
         invalid_node_type = 
           Enum.member?([
             "device/label",
-            "function",
             "integration"
           ], node_type) != true
 

--- a/lib/console/alerts/alerts.ex
+++ b/lib/console/alerts/alerts.ex
@@ -7,7 +7,6 @@ defmodule Console.Alerts do
   alias Console.Devices
   alias Console.Labels
   alias Console.Channels
-  alias Console.Functions
   
   def get_alert!(id), do: Repo.get!(Alert, id)
   def get_alert(id), do: Repo.get(Alert, id)
@@ -50,8 +49,6 @@ defmodule Console.Alerts do
         Labels.get_label!(organization, node_id)
       "integration" ->
         Channels.get_channel!(organization, node_id)
-      "function" ->
-        Functions.get_function!(organization, node_id)
     end
 
     alert_node = Repo.insert!(AlertNode.changeset(%AlertNode{}, %{ "alert_id" => alert.id, "node_id" => node_id, "node_type" => node_type }))
@@ -67,8 +64,6 @@ defmodule Console.Alerts do
         Labels.get_label!(organization, alert_node.node_id)
       "integration" ->
         Channels.get_channel!(organization, alert_node.node_id)
-      "function" ->
-        Functions.get_function!(organization, alert_node.node_id)
     end
     
     Repo.delete(alert_node)


### PR DESCRIPTION
Since no function alerts will be identified prior to MVP release, this PR removes all code related to them. Can easily be added back if function alert triggers are ever defined.

```
➜  console git:(flows) ✗ mix test test/console_web/controllers/v1/v1_alert_controller_test.exs
......

Finished in 0.3 seconds
6 tests, 0 failures

Randomized with seed 220294
➜  console git:(flows) ✗ mix test test/console_web/controllers/alert_controller_test.exs      
.....

Finished in 0.3 seconds
5 tests, 0 failures
```