### PR TITLE
fix build warnings

### DIFF
--- a/lib/console/alerts/alert_events.ex
+++ b/lib/console/alerts/alert_events.ex
@@ -3,8 +3,6 @@ defmodule Console.AlertEvents do
   alias Console.Repo
   alias Console.Alerts.AlertEvent
   alias Console.Alerts
-  alias Console.Labels
-  alias Console.Devices
 
   def create_alert_event(attrs \\ %{}) do
     %AlertEvent{}

--- a/lib/console/auth/auth.ex
+++ b/lib/console/auth/auth.ex
@@ -6,7 +6,6 @@ defmodule Console.Auth do
   import Ecto.Query, warn: false
   alias Console.Repo
   alias Console.Auth.User
-  alias Console.Organizations
 
   def get_user_by_id(id) do
     Repo.get(User, id)

--- a/lib/console/channels/channel.ex
+++ b/lib/console/channels/channel.ex
@@ -5,9 +5,6 @@ defmodule Console.Channels.Channel do
 
   alias Console.Organizations.Organization
   alias Console.Channels.Channel
-  alias Console.Labels.Label
-  alias Console.Labels.ChannelsLabels
-  alias Console.Devices.Device
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id

--- a/lib/console/channels/channels.ex
+++ b/lib/console/channels/channels.ex
@@ -8,8 +8,6 @@ defmodule Console.Channels do
 
   alias Console.Channels.Channel
   alias Console.Organizations.Organization
-  alias Console.Labels.ChannelsLabels
-  alias Console.Labels.DevicesLabels
 
   def get_channel!(id), do: Repo.get!(Channel, id)
 

--- a/lib/console/devices/device.ex
+++ b/lib/console/devices/device.ex
@@ -4,7 +4,6 @@ defmodule Console.Devices.Device do
 
   alias Console.Organizations.Organization
   alias Console.Events.Event
-  alias Console.Channels.Channel
   alias Console.Labels.DevicesLabels
   alias Console.Labels.Label
   alias Console.MultiBuys.MultiBuy

--- a/lib/console/devices/device_resolver.ex
+++ b/lib/console/devices/device_resolver.ex
@@ -171,9 +171,4 @@ defmodule Console.Devices.DeviceResolver do
 
     {:ok, device_imports}
   end
-
-  def all(_, %{context: %{current_organization: current_organization}}) do
-    devices = Ecto.assoc(current_organization, :devices) |> Repo.all()
-    {:ok, devices}
-  end
 end

--- a/lib/console/devices/devices.ex
+++ b/lib/console/devices/devices.ex
@@ -33,18 +33,12 @@ defmodule Console.Devices do
      |> Repo.all()
   end
 
-  def get_device(organization, id) do
-     Repo.get_by(Device, [id: id, organization_id: organization.id])
-  end
-
   def get_device_and_lock_for_add_device_event(device_id) do
     Device
       |> where([d], d.id == ^device_id)
       |> lock("FOR UPDATE")
       |> Repo.one()
   end
-
-  def get_device(id), do: Repo.get(Device, id)
 
   def get_by_dev_eui_app_eui(dev_eui, app_eui) do
      from(d in Device, where: d.dev_eui == ^dev_eui and d.app_eui == ^app_eui)

--- a/lib/console/functions/functions.ex
+++ b/lib/console/functions/functions.ex
@@ -4,7 +4,6 @@ defmodule Console.Functions do
 
   alias Console.Functions.Function
   alias Console.Organizations.Organization
-  alias Console.Labels.Label
 
   def get_function!(organization, id) do
      Repo.get_by!(Function, [id: id, organization_id: organization.id])

--- a/lib/console/helpers/helpers.ex
+++ b/lib/console/helpers/helpers.ex
@@ -38,7 +38,7 @@ defmodule Console.Helpers do
 
   def drop_keys_with_empty_map(map) do
     Enum.filter(map, fn i ->
-      {key, value} = i
+      {_key, value} = i
       value != %{}
     end)
   end

--- a/lib/console/labels/label.ex
+++ b/lib/console/labels/label.ex
@@ -5,10 +5,7 @@ defmodule Console.Labels.Label do
   alias Console.Organizations.Organization
   alias Console.Devices.Device
   alias Console.Labels.DevicesLabels
-  alias Console.Channels.Channel
-  alias Console.Labels.ChannelsLabels
   alias Console.MultiBuys.MultiBuy
-  alias Console.Functions.Function
   alias Console.Helpers
 
   @primary_key {:id, :binary_id, autogenerate: true}

--- a/lib/console/labels/labels.ex
+++ b/lib/console/labels/labels.ex
@@ -4,10 +4,8 @@ defmodule Console.Labels do
 
   alias Console.Labels.Label
   alias Console.Labels.DevicesLabels
-  alias Console.Labels.ChannelsLabels
   alias Console.Devices.Device
   alias Console.Devices
-  alias Console.Channels
   alias Console.Organizations.Organization
 
   def get_label!(id), do: Repo.get!(Label, id)

--- a/lib/console/memos/memo.ex
+++ b/lib/console/memos/memo.ex
@@ -1,7 +1,6 @@
 defmodule Console.Memos.Memo do
   use Ecto.Schema
   import Ecto.Changeset
-  alias Console.Organizations.Organization
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id

--- a/lib/console/multi_buys/multi_buy.ex
+++ b/lib/console/multi_buys/multi_buy.ex
@@ -5,6 +5,7 @@ defmodule Console.MultiBuys.MultiBuy do
 
   alias Console.Devices.Device
   alias Console.Labels.Label
+  alias Console.Organizations.Organization
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id

--- a/lib/console_web/controllers/channel_controller.ex
+++ b/lib/console_web/controllers/channel_controller.ex
@@ -3,11 +3,9 @@ defmodule ConsoleWeb.ChannelController do
 
   alias Console.Repo
   alias Console.Organizations
-  alias Console.Labels
   alias Console.Channels
   alias Console.Channels.Channel
   alias Console.Functions
-  alias Console.Functions.Function
   alias Console.Alerts
   alias Console.AlertEvents
   alias Console.Flows
@@ -26,7 +24,7 @@ defmodule ConsoleWeb.ChannelController do
       |> Ecto.Multi.run(:channel, fn _repo, _ ->
         Channels.create_channel(current_organization, channel_params)
       end)
-      |> Ecto.Multi.run(:function, fn _repo, %{ channel: channel } ->
+      |> Ecto.Multi.run(:function, fn _repo, %{ channel: _channel } ->
         case function_params["format"] do
            "custom" ->
             function = Functions.get_function!(current_organization, function_params["id"])

--- a/lib/console_web/controllers/downlink_controller.ex
+++ b/lib/console_web/controllers/downlink_controller.ex
@@ -12,7 +12,7 @@ defmodule ConsoleWeb.DownlinkController do
 
     case type do
       "device" ->
-        device = Devices.get_device!(current_organization, id)
+        Devices.get_device!(current_organization, id)
         ConsoleWeb.Endpoint.broadcast("device:all", "device:all:downlink:devices", %{ "channel_name" => "none", "devices" => [id], "payload" => conn.body_params })
 
         conn

--- a/lib/console_web/controllers/label_controller.ex
+++ b/lib/console_web/controllers/label_controller.ex
@@ -226,7 +226,7 @@ defmodule ConsoleWeb.LabelController do
           end)
           |> Repo.transaction()
 
-        with {:ok, %{devices_labels: {_, count}, label: label }} <- result do
+        with {:ok, %{devices_labels: {_, count}, label: _label }} <- result do
           ConsoleWeb.Endpoint.broadcast("graphql:device_index_labels_bar", "graphql:device_index_labels_bar:#{current_organization.id}:label_list_update", %{})
           device = Devices.get_device!(List.first(devices))
           ConsoleWeb.Endpoint.broadcast("graphql:devices_index_table", "graphql:devices_index_table:#{current_organization.id}:device_list_update", %{})

--- a/lib/console_web/controllers/multi_buy_controller.ex
+++ b/lib/console_web/controllers/multi_buy_controller.ex
@@ -1,7 +1,6 @@
 defmodule ConsoleWeb.MultiBuyController do
   use ConsoleWeb, :controller
 
-  alias Console.Repo
   alias Console.MultiBuys
   alias Console.Labels
   alias Console.Devices
@@ -70,7 +69,7 @@ defmodule ConsoleWeb.MultiBuyController do
 
   def add_multi_buy_to_node(conn, %{ "multi_buy_id" => multi_buy_id, "node_id" => node_id, "node_type" => node_type }) do
     current_organization = conn.assigns.current_organization
-    multi_buy = MultiBuys.get_multi_buy!(current_organization, multi_buy_id)
+    MultiBuys.get_multi_buy!(current_organization, multi_buy_id)
 
     case node_type do
       "Device" ->

--- a/lib/console_web/controllers/v1/downlink_controller.ex
+++ b/lib/console_web/controllers/v1/downlink_controller.ex
@@ -1,7 +1,5 @@
 defmodule ConsoleWeb.V1.DownlinkController do
   use ConsoleWeb, :controller
-  alias Console.Repo
-  alias Console.Devices
   alias Console.Channels
   alias Console.Labels
   alias Console.Flows


### PR DESCRIPTION
no build warnings when building:
```
➜  console git:(flows) ✗ iex -S mix phx.server
Erlang/OTP 21 [erts-10.1] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:1] [hipe]

Compiling 144 files (.ex)
Generated console app
[info] AppSignal disabled.
[info] Running ConsoleWeb.Endpoint with cowboy 2.7.0 at 0.0.0.0:4000 (http)
[info] Access ConsoleWeb.Endpoint at http://localhost:4000
[debug] [:nonode@nohost][Elixir.Quantum.JobBroadcaster] Loading Initial Jobs from Config
[debug] [:nonode@nohost][Elixir.Quantum.ExecutionBroadcaster] Adding job :delete_sent_alerts
[debug] [:nonode@nohost][Elixir.Quantum.ExecutionBroadcaster] Adding job :send_alerts
[debug] [:nonode@nohost][Elixir.Quantum.ExecutionBroadcaster] Adding job :trigger_device_stops_transmitting
Interactive Elixir (1.9.0) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> yarn run v1.22.10
$ webpack --mode development --watch-stdin

BREAK: (a)bort (c)ontinue (p)roc info (i)nfo (l)oaded
       (v)ersion (k)ill (D)b-tables (d)istribution
^C%      
```

one warning related to the decoder when testing:
```
➜  console git:(buildWarningss) ✗ mix test
Compiling 59 files (.ex)
warning: unused alias AccessTokenDecoder
  lib/console_web/channels/user_socket.ex:6

warning: unused alias AccessTokenDecoder
  lib/console_web/plug/verify_access_token.ex:44

warning: function Console.AccessTokenDecoder.MockDecodeAccessToken.decode_conn_access_token/1 is undefined (module Console.AccessTokenDecoder.MockDecodeAccessToken is not available)
Found at 2 locations:
  lib/console_web/channels/user_socket.ex:25
  lib/console_web/plug/verify_access_token.ex:56

...................................................

Finished in 1.1 seconds
51 tests, 0 failures
```