### PR TITLE
Fix overflow for Role Table

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -26,6 +26,10 @@ body {
   white-space: nowrap;
 }
 
+#RoleTable > div > div > table > tbody > tr > td.ant-table-cell {
+  white-space: normal;
+}
+
 .ant-input,
 .ant-select {
   font-size: 16px;


### PR DESCRIPTION
Keeping the prior rule (`white-space: no wrap`) for other `.ant-table-cell` elements since they work as intended for multiple tables.

Previously:
![image](https://user-images.githubusercontent.com/51131939/123182258-e2ecd000-d443-11eb-9cf1-e65d96d71118.png)

After PR:
![image](https://user-images.githubusercontent.com/51131939/123182318-0283f880-d444-11eb-8d3c-92188db63fae.png)
