### PR TITLE
Fix subscription so orgs are refetched upon adding new one from top bar

### DIFF
--- a/assets/js/components/common/TopBar.jsx
+++ b/assets/js/components/common/TopBar.jsx
@@ -32,7 +32,7 @@ class TopBar extends Component {
 
   componentDidMount() {
     const { socket, user } = this.props
-    const user_id = user.sub.slice(6)
+    const user_id = user.sub;
 
     this.channel = socket.channel("graphql:topbar_orgs", {})
     this.channel.join()


### PR DESCRIPTION
Previously, the user ID value was being sliced so it did not match the ID that was being used to broadcast a change in orgs. Thus, when user added a new org from top bar, it would not update the list and required a refresh to see the new org show up.