### PR TITLE
Fix other subscriptions w/ user_id

### DIFF
--- a/assets/js/components/common/TopBar.jsx
+++ b/assets/js/components/common/TopBar.jsx
@@ -32,7 +32,7 @@ class TopBar extends Component {
 
   componentDidMount() {
     const { socket, user } = this.props
-    const user_id = user.sub;
+    const user_id = user.sub.startsWith("auth0") ? user.sub.slice(6) : user.sub;
 
     this.channel = socket.channel("graphql:topbar_orgs", {})
     this.channel.join()

--- a/assets/js/components/devices/DeviceNew.jsx
+++ b/assets/js/components/devices/DeviceNew.jsx
@@ -50,7 +50,7 @@ class DeviceNew extends Component {
       (message) => {
         const { page, pageSize } = this.state;
         this.props.importsQuery.refetch({ page, pageSize });
-        const user_id = user.sub.slice(6);
+        const user_id = user.sub;
 
         if (user_id === message.user_id && message.status === "success") {
           this.setState({ importComplete: true });

--- a/assets/js/components/devices/DeviceNew.jsx
+++ b/assets/js/components/devices/DeviceNew.jsx
@@ -50,7 +50,7 @@ class DeviceNew extends Component {
       (message) => {
         const { page, pageSize } = this.state;
         this.props.importsQuery.refetch({ page, pageSize });
-        const user_id = user.sub;
+        const user_id = user.sub.startsWith("auth0") ? user.sub.slice(6) : user.sub;
 
         if (user_id === message.user_id && message.status === "success") {
           this.setState({ importComplete: true });

--- a/assets/js/components/organizations/OrganizationsTable.jsx
+++ b/assets/js/components/organizations/OrganizationsTable.jsx
@@ -24,7 +24,7 @@ class OrganizationsTable extends Component {
 
   componentDidMount() {
     const { socket, user } = this.props
-    const user_id = user.sub.slice(6)
+    const user_id = user.sub;
 
     this.channel = socket.channel("graphql:orgs_index_table", {})
     this.channel.join()

--- a/assets/js/components/organizations/OrganizationsTable.jsx
+++ b/assets/js/components/organizations/OrganizationsTable.jsx
@@ -24,7 +24,7 @@ class OrganizationsTable extends Component {
 
   componentDidMount() {
     const { socket, user } = this.props
-    const user_id = user.sub;
+    const user_id = user.sub.startsWith("auth0") ? user.sub.slice(6) : user.sub;
 
     this.channel = socket.channel("graphql:orgs_index_table", {})
     this.channel.join()


### PR DESCRIPTION
User IDs (from direct signup vs. Google auth) passed to components through `props` contain `auth0` at the beginning which is not included in the user ID retrieved from the connection. This was causing subscriptions and broadcasts to not have and thus breaking the subscription updates on the UI.