### PR TITLE
Include channel ID in details for notification event

### DIFF
--- a/lib/console_web/controllers/channel_controller.ex
+++ b/lib/console_web/controllers/channel_controller.ex
@@ -158,6 +158,7 @@ defmodule ConsoleWeb.ChannelController do
       if updated_channel != nil do
         { _, time } = Timex.format(Timex.now, "%H:%M:%S UTC", :strftime)
         details = %{
+          channel_id: channel.id,
           channel_name: updated_channel.channel_name,
           updated_by: conn.assigns.current_user.email,
           time: time
@@ -190,6 +191,7 @@ defmodule ConsoleWeb.ChannelController do
       if (deleted_channel != nil) do
         { _, time } = Timex.format(Timex.now, "%H:%M:%S UTC", :strftime)
         details = %{
+          channel_id: id,
           channel_name: deleted_channel.channel_name,
           deleted_by: conn.assigns.current_user.email,
           time: time


### PR DESCRIPTION
This fix is needed for the event migration script in https://github.com/helium/console/pull/646 to be successful. Since in 2.0, integrations are decoupled from labels, we need this data to persist in the details so it can be migrated successfully as an integration notification event.