### PR TITLE
Chunk massive app.js into separate bundles

### DIFF
--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = function(env) {
     entry: './js/app.js',
     output: {
       path: path.resolve(__dirname, '../priv/static/js'),
-      filename: 'app.js',
+      filename: '[name].bundle.js',
       publicPath: '/',
     },
     module: {
@@ -43,6 +43,61 @@ module.exports = function(env) {
     resolve: {
       modules: ['node_modules', path.resolve(__dirname, 'js')],
       extensions: ['.js', '.jsx'],
+    },
+    optimization: {
+      minimize: true,
+      runtimeChunk: 'single',
+      splitChunks: {
+        chunks: 'all',
+        maxInitialRequests: Infinity,
+        minSize: 0,
+        cacheGroups: {
+          antdVendor: {
+            test: /[\\/]node_modules[\\/](antd)[\\/]/,
+            name: "antd"
+          },
+          chartjsVendor: {
+            test: /[\\/]node_modules[\\/](chart.js)[\\/]/,
+            name: "chartjs"
+          },
+          flowVendor: {
+            test: /[\\/]node_modules[\\/](react-flow-renderer)[\\/]/,
+            name: "reactflow"
+          },
+          apolloVendor: {
+            test: /[\\/]node_modules[\\/](@apollo)[\\/]/,
+            name: "apollo"
+          },
+          amplitudeVendor: {
+            test: /[\\/]node_modules[\\/](amplitude-js)[\\/]/,
+            name: "amplitude"
+          },
+          antDesignVendor: {
+            test: /[\\/]node_modules[\\/](@ant-design)[\\/]/,
+            name: "antdesign"
+          },
+          auth0Vendor: {
+            test: /[\\/]node_modules[\\/](@auth0)[\\/]/,
+            name: "auth0"
+          },
+          utilityVendor: {
+            test: /[\\/]node_modules[\\/](lodash|moment)[\\/]/,
+            name: "utility"
+          },
+          sanitizeVendor: {
+            test: /[\\/]node_modules[\\/](sanitize-html)[\\/]/,
+            name: "sanitize"
+          },
+          reactReduxVendor: {
+            test: /[\\/]node_modules[\\/](react|react-dom|react-redux|redux)[\\/]/,
+            name: "reactredux"
+          },
+          vendor: {
+            test: /[\\/]node_modules[\\/](!antd)(!chart.js)(!react-flow-renderer)(!@apollo)(!amplitude-js)(!@ant-design)(!@auth0)(!lodash)(!moment)(!sanitize-html)(!react)(!react-dom)(!react-redux)(!redux)[\\/]/,
+            name: "vendor"
+          },
+        },
+      },
     },
     plugins: [
       new webpack.EnvironmentPlugin(['AUTH_0_DOMAIN', 'AUTH_0_CLIENT_ID', 'ENV_DOMAIN', 'STRIPE_PUBLIC_KEY', 'SELF_HOSTED', 'INTERCOM_ID_SECRET', 'CONSOLE_VERSION', 'RELEASE_BLOG_LINK']),

--- a/lib/console_web/templates/layout/app.html.eex
+++ b/lib/console_web/templates/layout/app.html.eex
@@ -29,7 +29,19 @@
       </main>
 
     </div> <!-- /container -->
-    <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
+    <script src="<%= static_path(@conn, "/js/reactredux.bundle.js") %>"></script>
+    <script src="<%= static_path(@conn, "/js/auth0.bundle.js") %>"></script>
+    <script src="<%= static_path(@conn, "/js/apollo.bundle.js") %>"></script>
+    <script src="<%= static_path(@conn, "/js/antd.bundle.js") %>"></script>
+    <script src="<%= static_path(@conn, "/js/antdesign.bundle.js") %>"></script>
+    <script src="<%= static_path(@conn, "/js/amplitude.bundle.js") %>"></script>
+    <script src="<%= static_path(@conn, "/js/reactflow.bundle.js") %>"></script>
+    <script src="<%= static_path(@conn, "/js/chartjs.bundle.js") %>"></script>
+    <script src="<%= static_path(@conn, "/js/sanitize.bundle.js") %>"></script>
+    <script src="<%= static_path(@conn, "/js/utility.bundle.js") %>"></script>
+    <script src="<%= static_path(@conn, "/js/vendors~main.bundle.js") %>"></script>
+    <script src="<%= static_path(@conn, "/js/main.bundle.js") %>"></script>
+    <script src="<%= static_path(@conn, "/js/runtime.bundle.js") %>"></script>
     <iframe id="myFrame" sandbox="allow-scripts" style="height:0px;width:0px;opacity:0;position:absolute;top:0;"
       srcdoc="<html><head><script>window.addEventListener('message', function (e) {var mainWindow = e.source;var result = '';try {result = eval(e.data);} catch (e) {result = 'Your function threw an exception';}mainWindow.postMessage(result, event.origin);});</script></head></html>"
     >


### PR DESCRIPTION
Benefits of chunking like this:
1. Users can download the previously single large js file in chunks in parallel
2. Users can cache these chunks that won't change very often

This chunking setup does not lazy load, so first time users still need to download 8.4MB worth of js, but subsequently visits will be faster due to caching.