### PR TITLE
Remove special logic for devices w/ no labels + Fixes for last modified on node sidebar

### DIFF
--- a/assets/js/components/devices/DeviceIndexTable.jsx
+++ b/assets/js/components/devices/DeviceIndexTable.jsx
@@ -126,10 +126,7 @@ class DeviceIndexTable extends Component {
         dataIndex: "name",
         sorter: true,
         render: (text, record) => (
-          <Link
-            className={record.labels.length === 0 ? "dull" : undefined}
-            to={`/devices/${record.id}`}
-          >
+          <Link to={`/devices/${record.id}`}>
             {text}
             {moment()
               .utc()
@@ -178,7 +175,7 @@ class DeviceIndexTable extends Component {
                   </UserCan>
                 ))
               ) : (
-                <Text type="danger">None</Text>
+                <Text>None</Text>
               )}
             </React.Fragment>
           );

--- a/assets/js/components/devices/DeviceShow.jsx
+++ b/assets/js/components/devices/DeviceShow.jsx
@@ -254,13 +254,13 @@ class DeviceShow extends Component {
       );
     if (error)
       return (
-        <FunctionDashboardLayout {...this.props}>
+        <DeviceDashboardLayout {...this.props}>
           <div style={{ padding: 40 }}>
             <Text>
               Data failed to load, please reload the page and try again
             </Text>
           </div>
-        </FunctionDashboardLayout>
+        </DeviceDashboardLayout>
       );
     const smallerText = device.total_packets > 10000;
 

--- a/assets/js/graphql/devices.js
+++ b/assets/js/graphql/devices.js
@@ -15,6 +15,7 @@ export const DEVICE_FRAGMENT = gql`
     adr_allowed
     multi_buy_id
     cf_list_enabled
+    updated_at
   }
 `;
 

--- a/assets/js/graphql/labels.js
+++ b/assets/js/graphql/labels.js
@@ -14,6 +14,7 @@ export const LABEL_FRAGMENT = gql`
       last_connected
     }
     cf_list_enabled
+    updated_at
   }
 `;
 

--- a/lib/console_web/schema/schema.ex
+++ b/lib/console_web/schema/schema.ex
@@ -35,6 +35,7 @@ defmodule ConsoleWeb.Schema do
     field :multi_buy_id, :id
     field :alerts, list_of(:alert)
     field :cf_list_enabled, :boolean
+    field :updated_at, :naive_datetime
   end
 
   object :device_stats do
@@ -98,6 +99,7 @@ defmodule ConsoleWeb.Schema do
     field :multi_buy_id, :id
     field :alerts, list_of(:alert)
     field :cf_list_enabled, :boolean
+    field :updated_at, :naive_datetime
   end
 
   paginated object :channel do


### PR DESCRIPTION
Fixes issue where "Last Modified" for devices and labels would show current time since the `updated_at` time was not being pulled (https://github.com/helium/console/issues/707)

Removes special logic that dulled the device name and showed None in red when it had no labels (per product request)
![image](https://user-images.githubusercontent.com/51131939/126373877-17252e27-4134-493b-acb4-9afe414c8947.png)
