### PR TITLE
Fix adding new label to device requiring refresh

### DIFF
--- a/assets/js/components/devices/DevicesAddLabelModal.jsx
+++ b/assets/js/components/devices/DevicesAddLabelModal.jsx
@@ -61,7 +61,7 @@ class DevicesAddLabelModal extends Component {
       <Modal
         title={`Add Label to ${
           devicesToUpdate ? devicesToUpdate.length : 0
-        } Devices`}
+        } Device${devicesToUpdate && devicesToUpdate.length > 1 ? "s" : ""}`}
         visible={open}
         centered
         onCancel={onClose}

--- a/lib/console_web/controllers/label_controller.ex
+++ b/lib/console_web/controllers/label_controller.ex
@@ -234,6 +234,7 @@ defmodule ConsoleWeb.LabelController do
           device = Devices.get_device!(List.first(devices))
           ConsoleWeb.Endpoint.broadcast("graphql:devices_index_table", "graphql:devices_index_table:#{current_organization.id}:device_list_update", %{})
           ConsoleWeb.Endpoint.broadcast("graphql:device_show", "graphql:device_show:#{device.id}:device_update", %{})
+          ConsoleWeb.Endpoint.broadcast("graphql:device_show_labels_table", "graphql:device_show_labels_table:#{device.id}:device_update", %{})
 
           broadcast_router_update_devices(devices)
 


### PR DESCRIPTION
Due to missing broadcast when adding a new label to a device, the device show page required a refresh to see the new label added on the list.

Also fixed text on modal to be singular when only 1 device is selected