### PR TITLE
Send custom xor filter removal error to appsignal

### DIFF
--- a/lib/console/devices/devices.ex
+++ b/lib/console/devices/devices.ex
@@ -38,6 +38,11 @@ defmodule Console.Devices do
      |> Repo.all()
   end
 
+  def get_devices_in_list(ids) do
+     from(d in Device, where: d.id in ^ids)
+     |> Repo.all()
+  end
+
   def get_device_and_lock_for_add_device_event(device_id) do
     Device
       |> where([d], d.id == ^device_id)

--- a/lib/console_web/controllers/router/device_controller.ex
+++ b/lib/console_web/controllers/router/device_controller.ex
@@ -426,7 +426,7 @@ defmodule ConsoleWeb.Router.DeviceController do
     end
   end
 
-  def update_devices_in_xor_filter(conn, %{"added" => added_device_ids, "removed" => _removed_device_ids}) do
+  def update_devices_in_xor_filter(conn, %{"added" => added_device_ids, "removed" => removed_device_ids}) do
     if length(added_device_ids) > 0 do
       with {:ok, devices} <- Devices.update_in_xor_filter(added_device_ids) do
         Enum.map(devices,fn (d) -> d.organization_id end)
@@ -442,6 +442,12 @@ defmodule ConsoleWeb.Router.DeviceController do
       end
     else
       conn |> send_resp(200, "")
+    end
+
+    removed_devices = Devices.get_devices_in_list(removed_device_ids)
+    if length(removed_devices) > 0 do
+      ids_to_report = removed_devices |> Enum.map(fn d -> d.id end)
+      Appsignal.send_error(%RuntimeError{ message: Enum.join(ids_to_report, ", ") }, "Removed devices in XOR filter that exist", ["router/device_controller.ex/update_devices_in_xor_filter"])
     end
   end
 end


### PR DESCRIPTION
Creates a way to send "incidents" to appsignal for tracking certain events that shouldn't error out in the conventional way, but we should keep a log of such incidents. Starting off with the removal of existing devices from xor filter for now. We will add more to the "incident" log going forward.