### PR TITLE
Make self-hosted Console utilize SOCKET_CHECK_ORIGIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ cp templates/nginx-default.conf nginx.conf
 
 - Get a certificate (https://certbot.eff.org/instructions)
 - Update `nginx.conf` with cert and key information
-- Update `docker-config.yaml` `socket_check_origin` to reflect your hosted URL
+- In `.env`, set `SOCKET_CHECK_ORIGIN`
 - Build with `docker-compose build`
 - Run with `docker-compose up`
 

--- a/templates/.env
+++ b/templates/.env
@@ -17,3 +17,4 @@ DATABASE_USER=postgres
 DATABASE_PASSWORD=postgres
 BLOCKCHAIN_API_RETRY="1"
 BLOCKCHAIN_API_URL="https://api.helium.wtf/v1"
+SOCKET_CHECK_ORIGIN="https://[Your host domain]"

--- a/templates/docker-compose-local.yaml
+++ b/templates/docker-compose-local.yaml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        socket_check_origin: "//localhost"
+        socket_check_origin: "${SOCKET_CHECK_ORIGIN}"
     image: helium/console:latest
     container_name: helium_console
     restart: always

--- a/templates/docker-compose-local.yaml
+++ b/templates/docker-compose-local.yaml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        socket_check_origin: "${SOCKET_CHECK_ORIGIN}"
+        socket_check_origin: "//localhost"
     image: helium/console:latest
     container_name: helium_console
     restart: always

--- a/templates/docker-compose-server.yaml
+++ b/templates/docker-compose-server.yaml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        socket_check_origin: "https//console.example.com"
+        socket_check_origin: "${SOCKET_CHECK_ORIGIN}"
     image: helium/console:latest
     container_name: helium_console
     restart: always


### PR DESCRIPTION
SOCKET_CHECK_ORIGIN is already used elsewhere.

Without this change, websocket connections don't work. They used to
work, but stopped working some time around the v2 upgrade.