### PR TITLE
Mapbox loading issue

### DIFF
--- a/assets/js/components/common/Mapbox.jsx
+++ b/assets/js/components/common/Mapbox.jsx
@@ -50,26 +50,35 @@ export default ({ orgHotspotsMap, data }) => {
 
   const [mapPoints, setMapPoints] = useState(generateMapPoints());
 
+  const loadMapPoints = () => {
+    map.current.getSource("hotspots-points-data").setData({
+      type: "FeatureCollection",
+      features: mapPoints,
+    });
+
+    if (mapPoints.length > 1) {
+      var bounds = new mapboxgl.LngLatBounds();
+
+      mapPoints.forEach(function (feature) {
+        bounds.extend(feature.geometry.coordinates);
+      });
+
+      map.current.fitBounds(bounds, { padding: 80 });
+    }
+  };
+
   useEffect(() => {
     setMapPoints(generateMapPoints());
   }, [orgHotspotsMap, data]);
 
   useEffect(() => {
     if (map.current) {
-      map.current.getSource("hotspots-points-data") &&
-        map.current.getSource("hotspots-points-data").setData({
-          type: "FeatureCollection",
-          features: mapPoints,
-        });
-
-      if (mapPoints.length > 1) {
-        var bounds = new mapboxgl.LngLatBounds();
-
-        mapPoints.forEach(function (feature) {
-          bounds.extend(feature.geometry.coordinates);
-        });
-
-        map.current.fitBounds(bounds, { padding: 80 });
+      if (map.current.getSource("hotspots-points-data")) {
+        loadMapPoints();
+      } else {
+        setTimeout(function () {
+          loadMapPoints();
+        }, 2000);
       }
     }
   }, [mapPoints]);


### PR DESCRIPTION
Adding the empty data resource at first and setting the data for the points on the map were _sometimes_ hitting a race condition, resulting in the points sometimes not rendering on the first load. This PR addresses the issue by delaying setting the data by 2 seconds in the edge case that the resource is not finished being added to the map. In my opinion, the extra 2 second does not affect the UX since it happens while the map is resetting to recenter based on the data points.