### PR TITLE
Add index for device id on hotspots stats

### DIFF
--- a/priv/repo/migrations/20210910182205_add_index_to_hotspot_stats.exs
+++ b/priv/repo/migrations/20210910182205_add_index_to_hotspot_stats.exs
@@ -1,0 +1,7 @@
+defmodule Console.Repo.Migrations.AddIndexToHotspotStats do
+  use Ecto.Migration
+
+  def change do
+    create index(:hotspot_stats, [:device_id])
+  end
+end


### PR DESCRIPTION
deleting devices (even newly created ones) was taking a long time:

```
explain (analyze,buffers,timing) delete from devices where id = '8a7b211b-5376-4e2c-9bf9-19b26c345c27';
                                                         QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------
 Delete on devices  (cost=0.08..4.09 rows=1 width=6) (actual time=0.076..0.077 rows=0 loops=1)
   Buffers: shared hit=6
   ->  Index Scan using devices_pkey on devices  (cost=0.08..4.09 rows=1 width=6) (actual time=0.057..0.058 rows=1 loops=1)
         Index Cond: (id = '8a7b211b-5376-4e2c-9bf9-19b26c345c27'::uuid)
         Buffers: shared hit=4
 Planning Time: 0.081 ms
 Trigger for constraint device_stats_device_id_fkey: time=0.737 calls=1
 Trigger for constraint devices_labels_device_id_fkey: time=0.286 calls=1
 Trigger for constraint flows_device_id_fkey: time=1.072 calls=1
 Trigger for constraint hotspot_stats_device_id_fkey: time=4164.577 calls=1
 Execution Time: 4166.785 ms
(11 rows)
```