### PR TITLE
Confirm label attachment when profiles conflict

### DIFF
--- a/assets/js/components/common/ConfirmLabelAddProfileConflict.jsx
+++ b/assets/js/components/common/ConfirmLabelAddProfileConflict.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Modal, Button, Typography } from "antd";
+const { Text } = Typography;
+
+export default ({ open, close, submit, multipleDevices }) => {
+  const handleSubmit = () => {
+    submit();
+    close();
+  };
+
+  return (
+    <Modal
+      title="Confirm Label Attachment"
+      visible={open}
+      onCancel={close}
+      centered
+      onOk={handleSubmit}
+      footer={[
+        <Button key="back" onClick={close}>
+          Cancel
+        </Button>,
+        <Button key="submit" type="primary" onClick={handleSubmit}>
+          Add Label
+        </Button>,
+      ]}
+    >
+      <div style={{ textAlign: "center" }}>
+        <Text>
+          {`The label you are trying to add has a different profile than ${
+            multipleDevices ? "one or more of the devices" : "the device"
+          }. Label profiles override device profiles.`}
+          <br />
+          <br />
+          {`Are you sure you want to add this label to ${
+            multipleDevices ? "these devices" : "the device"
+          }?`}
+        </Text>
+      </div>
+    </Modal>
+  );
+};

--- a/assets/js/components/devices/DevicesAddLabelModal.jsx
+++ b/assets/js/components/devices/DevicesAddLabelModal.jsx
@@ -10,12 +10,14 @@ import LabelTag from "../common/LabelTag";
 import { Modal, Button, Typography, Input, Select, Checkbox } from "antd";
 const { Text } = Typography;
 const { Option } = Select;
+import ConfirmLabelAddProfileConflict from "../common/ConfirmLabelAddProfileConflict";
 
 class DevicesAddLabelModal extends Component {
   state = {
     labelId: undefined,
     labelName: undefined,
     applyToAll: false,
+    showConfirmModal: false,
   };
 
   handleInputUpdate = (e) => {
@@ -24,31 +26,53 @@ class DevicesAddLabelModal extends Component {
 
   handleSubmit = (e) => {
     e.preventDefault();
+
     const { labelName, labelId, applyToAll } = this.state;
     const deviceIds = applyToAll
       ? []
       : this.props.devicesToUpdate.map((d) => d.id);
 
     if (labelId) {
-      this.props.addDevicesToLabel(!applyToAll && deviceIds, labelId)
-      .then(response => {
-        if (response.status === 204) {
-          analyticsLogger.logEvent("ACTION_ADD_LABEL_TO_DEVICES", {
-            devices: applyToAll ? "all" : deviceIds,
-            label: labelId,
+      const devicesProfiles = this.props.devicesToUpdate.reduce(
+        (result, device) => {
+          if (device.config_profile_id) {
+            result.push(device.config_profile_id);
+          }
+          return result;
+        },
+        []
+      );
+      const labelToApply = this.props.allLabelsQuery.allLabels.find(
+        (l) => l.id === labelId
+      );
+      if (
+        labelToApply.config_profile_id &&
+        devicesProfiles.some((p) => p !== labelToApply.config_profile_id)
+      ) {
+        this.setState({ showConfirmModal: true });
+      } else {
+        this.props
+          .addDevicesToLabel(!applyToAll && deviceIds, labelId)
+          .then((response) => {
+            if (response.status === 204) {
+              analyticsLogger.logEvent("ACTION_ADD_LABEL_TO_DEVICES", {
+                devices: applyToAll ? "all" : deviceIds,
+                label: labelId,
+              });
+            }
           });
-        }
-      })
+      }
     } else if (labelName) {
-      this.props.addDevicesToNewLabel(!applyToAll && deviceIds, labelName)
-      .then(response => {
-        if (response.status === 204) {
-          analyticsLogger.logEvent("ACTION_ADD_LABEL_TO_DEVICES", {
-            devices: applyToAll ? "all" : deviceIds,
-            label_name: labelName,
-          });
-        }
-      })
+      this.props
+        .addDevicesToNewLabel(!applyToAll && deviceIds, labelName)
+        .then((response) => {
+          if (response.status === 204) {
+            analyticsLogger.logEvent("ACTION_ADD_LABEL_TO_DEVICES", {
+              devices: applyToAll ? "all" : deviceIds,
+              label_name: labelName,
+            });
+          }
+        });
     }
     this.setState({ applyToAll: false });
 
@@ -66,74 +90,101 @@ class DevicesAddLabelModal extends Component {
     const { labelName, labelId } = this.state;
 
     return (
-      <Modal
-        title={`Add Label to ${
-          devicesToUpdate ? devicesToUpdate.length : 0
-        } Device${devicesToUpdate && devicesToUpdate.length > 1 ? "s" : ""}`}
-        visible={open}
-        centered
-        onCancel={onClose}
-        onOk={this.handleSubmit}
-        footer={[
-          <Button key="back" onClick={onClose}>
-            Cancel
-          </Button>,
-          <Button
-            key="submit"
-            onClick={this.handleSubmit}
-            enabled={
-              devicesToUpdate &&
-              devicesToUpdate.length !== 0 &&
-              (labelName || labelId)
-            }
-            type="primary"
-          >
-            Add Label
-          </Button>,
-        ]}
-      >
-        <div>
-          <Select
-            placeholder={error ? "No Labels found..." : "Choose Label"}
-            style={{ width: 270, marginRight: 10 }}
-            onSelect={this.handleSelectOption}
-            value={labelId}
-          >
-            {allLabels &&
-              allLabels.map((l) => (
-                <Option value={l.id} key={l.id}>
-                  <LabelTag text={l.name} />
-                </Option>
-              ))}
-          </Select>
-        </div>
+      <>
+        <Modal
+          title={`Add Label to ${
+            devicesToUpdate ? devicesToUpdate.length : 0
+          } Device${devicesToUpdate && devicesToUpdate.length > 1 ? "s" : ""}`}
+          visible={open}
+          centered
+          onCancel={onClose}
+          onOk={this.handleSubmit}
+          footer={[
+            <Button key="back" onClick={onClose}>
+              Cancel
+            </Button>,
+            <Button
+              key="submit"
+              onClick={this.handleSubmit}
+              enabled={
+                devicesToUpdate &&
+                devicesToUpdate.length !== 0 &&
+                (labelName || labelId)
+              }
+              type="primary"
+            >
+              Add Label
+            </Button>,
+          ]}
+        >
+          <div>
+            <Select
+              placeholder={error ? "No Labels found..." : "Choose Label"}
+              style={{ width: 270, marginRight: 10 }}
+              onSelect={this.handleSelectOption}
+              value={labelId}
+            >
+              {allLabels &&
+                allLabels.map((l) => (
+                  <Option value={l.id} key={l.id}>
+                    <LabelTag text={l.name} />
+                  </Option>
+                ))}
+            </Select>
+          </div>
 
-        <div style={{ marginTop: 15, marginBottom: 15 }}>
-          <Text style={{ color: grayForModalCaptions }}>or</Text>
-        </div>
+          <div style={{ marginTop: 15, marginBottom: 15 }}>
+            <Text style={{ color: grayForModalCaptions }}>or</Text>
+          </div>
 
-        <div>
-          <Text>Add Label</Text>
-          <Input
-            placeholder="Enter Label Name"
-            name="labelName"
-            value={this.state.labelName}
-            onChange={this.handleInputUpdate}
-          />
-          <Text style={{ marginBottom: 20, color: grayForModalCaptions }}>
-            Label names must be unique
-          </Text>
-        </div>
-        {allDevicesSelected && (
-          <Checkbox
-            style={{ marginTop: 20 }}
-            checked={this.state.applyToAll}
-            onChange={(e) => this.setState({ applyToAll: e.target.checked })}
-          >
-            {`Apply to all ${totalDevices} devices?`}
-          </Checkbox>
-        )}
-      </Modal>
+          <div>
+            <Text>Add Label</Text>
+            <Input
+              placeholder="Enter Label Name"
+              name="labelName"
+              value={this.state.labelName}
+              onChange={this.handleInputUpdate}
+            />
+            <Text style={{ marginBottom: 20, color: grayForModalCaptions }}>
+              Label names must be unique
+            </Text>
+          </div>
+          {allDevicesSelected && (
+            <Checkbox
+              style={{ marginTop: 20 }}
+              checked={this.state.applyToAll}
+              onChange={(e) => this.setState({ applyToAll: e.target.checked })}
+            >
+              {`Apply to all ${totalDevices} devices?`}
+            </Checkbox>
+          )}
+        </Modal>
+        <ConfirmLabelAddProfileConflict
+          open={this.state.showConfirmModal}
+          close={() => {
+            this.setState({ showConfirmModal: false });
+          }}
+          submit={() => {
+            const { applyToAll } = this.state;
+            const deviceIds = applyToAll
+              ? []
+              : this.props.devicesToUpdate.map((d) => d.id);
+            this.props
+              .addDevicesToLabel(!applyToAll && deviceIds, labelId)
+              .then((response) => {
+                if (response.status === 204) {
+                  analyticsLogger.logEvent("ACTION_ADD_LABEL_TO_DEVICES", {
+                    devices: applyToAll ? "all" : deviceIds,
+                    label: labelId,
+                  });
+                }
+              });
+          }}
+          multipleDevices={
+            this.props.devicesToUpdate && this.props.devicesToUpdate.length > 1
+          }
+        />
+      </>
     );
   }
 }

--- a/assets/js/components/labels/LabelAddDeviceModal.jsx
+++ b/assets/js/components/labels/LabelAddDeviceModal.jsx
@@ -6,6 +6,7 @@ import { ALL_LABELS_DEVICES } from "../../graphql/labels";
 import { Modal, Button, Typography, Tabs } from "antd";
 import LabelAddDeviceSelect from "./LabelAddDeviceSelect";
 import LabelAddLabelSelect from "./LabelAddLabelSelect";
+import ConfirmLabelAddProfileConflict from "../common/ConfirmLabelAddProfileConflict";
 const { Text } = Typography;
 const { TabPane } = Tabs;
 
@@ -13,29 +14,51 @@ class LabelAddDeviceModal extends Component {
   state = {
     checkedDevices: {},
     checkedLabels: {},
+    showConfirmModal: false,
   };
 
   handleSubmit = () => {
     const { checkedDevices, checkedLabels } = this.state;
 
-    this.props.addDevicesToLabels(
-      checkedDevices,
-      checkedLabels,
-      this.props.label.id
-    ).then(response => {
-      if (response.status === 200) {
-        analyticsLogger.logEvent("ACTION_ADD_DEVICES_AND_LABELS_TO_LABEL", {
-          id: this.props.label.id,
-          devices: Object.keys(checkedDevices),
-          labels: Object.keys(checkedLabels),
-        });
+    const checkedDevicesProfiles = [
+      ...Object.values(checkedDevices).reduce((result, device) => {
+        if (device.configProfileId) {
+          result.push(device.configProfileId);
+        }
+        return result;
+      }, []),
+      ...Object.values(checkedLabels).reduce((result, label) => {
+        if (label.configProfileIds) {
+          result.push(...label.configProfileIds);
+        }
+        return result;
+      }, []),
+    ];
+    if (
+      this.props.label.config_profile_id &&
+      checkedDevicesProfiles.some(
+        (p) => p !== this.props.label.config_profile_id
+      )
+    ) {
+      this.setState({ showConfirmModal: true });
+    } else {
+      this.props
+        .addDevicesToLabels(checkedDevices, checkedLabels, this.props.label.id)
+        .then((response) => {
+          if (response.status === 200) {
+            analyticsLogger.logEvent("ACTION_ADD_DEVICES_AND_LABELS_TO_LABEL", {
+              id: this.props.label.id,
+              devices: Object.keys(checkedDevices),
+              labels: Object.keys(checkedLabels),
+            });
 
-        this.setState({
-          checkedDevices: {},
-          checkedLabels: {},
-        })
-      }
-    })
+            this.setState({
+              checkedDevices: {},
+              checkedLabels: {},
+            });
+          }
+        });
+    }
 
     this.props.onClose();
   };
@@ -47,25 +70,27 @@ class LabelAddDeviceModal extends Component {
     } else if (search.length > 0) {
       const devices = {};
       search.forEach((d) => {
-        devices[d.id] = true;
+        devices[d.id] = { configProfileId: d.config_profile_id };
       });
       this.setState({ checkedDevices: devices });
     } else {
       const devices = {};
       this.props.allResourcesQuery.allDevices.forEach((d) => {
-        devices[d.id] = true;
+        devices[d.id] = { configProfileId: d.config_profile_id };
       });
       this.setState({ checkedDevices: devices });
     }
   };
 
-  checkSingleDevice = (id) => {
+  checkSingleDevice = (id, configProfileId) => {
     const { checkedDevices } = this.state;
     let devices;
     if (checkedDevices[id]) {
       devices = omit(checkedDevices, id);
     } else {
-      devices = Object.assign({}, checkedDevices, { [id]: true });
+      devices = Object.assign({}, checkedDevices, {
+        [id]: { configProfileId },
+      });
     }
     this.setState({ checkedDevices: devices });
   };
@@ -77,26 +102,42 @@ class LabelAddDeviceModal extends Component {
     } else if (search.length > 0) {
       const labels = {};
       search.forEach((l) => {
-        if (this.props.label.id !== l.id) labels[l.id] = true;
+        if (this.props.label.id !== l.id)
+          labels[l.id] = {
+            configProfileIds: l.devices.reduce((result, device) => {
+              if (device.config_profile_id) {
+                result.push(device.config_profile_id);
+              }
+              return result;
+            }, []),
+          };
       });
       this.setState({ checkedLabels: labels });
     } else {
       const labels = {};
       this.props.allResourcesQuery.allLabels.forEach((l) => {
-        if (this.props.label.id !== l.id) labels[l.id] = true;
+        if (this.props.label.id !== l.id)
+          labels[l.id] = {
+            configProfileIds: l.devices.reduce((result, device) => {
+              if (device.config_profile_id) {
+                result.push(device.config_profile_id);
+              }
+              return result;
+            }, []),
+          };
       });
       this.setState({ checkedLabels: labels });
     }
   };
 
-  checkSingleLabel = (id) => {
+  checkSingleLabel = (id, configProfileIds) => {
     const { checkedLabels } = this.state;
     let labels;
 
     if (checkedLabels[id]) {
       labels = omit(checkedLabels, id);
     } else {
-      labels = Object.assign({}, checkedLabels, { [id]: true });
+      labels = Object.assign({}, checkedLabels, { [id]: { configProfileIds } });
     }
     this.setState({ checkedLabels: labels });
   };
@@ -108,68 +149,108 @@ class LabelAddDeviceModal extends Component {
     const { checkedDevices, checkedLabels } = this.state;
 
     return (
-      <Modal
-        title="Which Devices do you want to add this Label to?"
-        visible={open}
-        onCancel={onClose}
-        centered
-        onOk={this.handleSubmit}
-        footer={[
-          <Button key="back" onClick={onClose}>
-            Cancel
-          </Button>,
-          <Button key="submit" type="primary" onClick={this.handleSubmit}>
-            Add Label to Devices
-          </Button>,
-        ]}
-        width={620}
-      >
-        {!loading && !error && (
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "row",
-              justifyContent: "center",
-            }}
-          >
-            <Tabs
-              defaultActiveKey="devices"
-              size="small"
-              onTabClick={(tab) => this.setState({ tab })}
-              tabPosition="left"
-              style={{ width: "100%", height: 325 }}
+      <>
+        <Modal
+          title="Which Devices do you want to add this Label to?"
+          visible={open}
+          onCancel={onClose}
+          centered
+          onOk={this.handleSubmit}
+          footer={[
+            <Button key="back" onClick={onClose}>
+              Cancel
+            </Button>,
+            <Button key="submit" type="primary" onClick={this.handleSubmit}>
+              Add Label to Devices
+            </Button>,
+          ]}
+          width={620}
+        >
+          {!loading && !error && (
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                justifyContent: "center",
+              }}
             >
-              <TabPane tab="Devices" key="devices">
-                <LabelAddDeviceSelect
-                  checkAllDevices={this.checkAllDevices}
-                  allDevices={allDevices}
-                  checkedDevices={checkedDevices}
-                  checkSingleDevice={this.checkSingleDevice}
-                  labelNormalizedDevices={labelNormalizedDevices}
-                />
-              </TabPane>
-              <TabPane tab="Labels" key="labels">
-                <Text strong>
-                  Choose additional labels with devices that you want attached
-                  to the current label, {label.name}:
-                </Text>
-                <LabelAddLabelSelect
-                  checkAllLabels={this.checkAllLabels}
-                  allLabelsWithDevices={allLabels.filter(
-                    (l) => l.device_count && l.device_count > 0
-                  )}
-                  checkedLabels={checkedLabels}
-                  checkSingleLabel={this.checkSingleLabel}
-                  currentLabel={label}
-                />
-              </TabPane>
-            </Tabs>
-          </div>
-        )}
-        {error && (
-          <Text>Data failed to load, please reload the page and try again</Text>
-        )}
-      </Modal>
+              <Tabs
+                defaultActiveKey="devices"
+                size="small"
+                onTabClick={(tab) => this.setState({ tab })}
+                tabPosition="left"
+                style={{ width: "100%", height: 325 }}
+              >
+                <TabPane tab="Devices" key="devices">
+                  <LabelAddDeviceSelect
+                    checkAllDevices={this.checkAllDevices}
+                    allDevices={allDevices}
+                    checkedDevices={checkedDevices}
+                    checkSingleDevice={this.checkSingleDevice}
+                    labelNormalizedDevices={labelNormalizedDevices}
+                  />
+                </TabPane>
+                <TabPane tab="Labels" key="labels">
+                  <Text strong>
+                    Choose additional labels with devices that you want attached
+                    to the current label, {label.name}:
+                  </Text>
+                  <LabelAddLabelSelect
+                    checkAllLabels={this.checkAllLabels}
+                    allLabelsWithDevices={allLabels.filter(
+                      (l) => l.device_count && l.device_count > 0
+                    )}
+                    checkedLabels={checkedLabels}
+                    checkSingleLabel={this.checkSingleLabel}
+                    currentLabel={label}
+                  />
+                </TabPane>
+              </Tabs>
+            </div>
+          )}
+          {error && (
+            <Text>
+              Data failed to load, please reload the page and try again
+            </Text>
+          )}
+        </Modal>
+        <ConfirmLabelAddProfileConflict
+          open={this.state.showConfirmModal}
+          close={() => {
+            this.setState({ showConfirmModal: false });
+          }}
+          multipleDevices={
+            Object.keys(checkedDevices).length > 1 ||
+            Object.keys(checkedLabels).length > 0
+          }
+          submit={() => {
+            const { checkedDevices, checkedLabels } = this.state;
+            this.props
+              .addDevicesToLabels(
+                checkedDevices,
+                checkedLabels,
+                this.props.label.id
+              )
+              .then((response) => {
+                if (response.status === 200) {
+                  analyticsLogger.logEvent(
+                    "ACTION_ADD_DEVICES_AND_LABELS_TO_LABEL",
+                    {
+                      id: this.props.label.id,
+                      devices: Object.keys(checkedDevices),
+                      labels: Object.keys(checkedLabels),
+                    }
+                  );
+
+                  this.setState({
+                    checkedDevices: {},
+                    checkedLabels: {},
+                  });
+                }
+              });
+          }}
+        />
+      </>
     );
   }
 }

--- a/assets/js/components/labels/LabelAddDeviceSelect.jsx
+++ b/assets/js/components/labels/LabelAddDeviceSelect.jsx
@@ -59,7 +59,7 @@ class LabelAddDeviceSelect extends Component {
             allDevices.map((d) => (
               <div style={{ marginTop: 5 }} key={d.id}>
                 <Checkbox
-                  onChange={() => checkSingleDevice(d.id)}
+                  onChange={() => checkSingleDevice(d.id, d.config_profile_id)}
                   checked={checkedDevices[d.id]}
                 >
                   {d.name}

--- a/assets/js/components/labels/LabelAddLabelSelect.jsx
+++ b/assets/js/components/labels/LabelAddLabelSelect.jsx
@@ -70,7 +70,17 @@ class LabelAddLabelSelect extends Component {
               return (
                 <div style={{ marginTop: 5 }} key={l.id}>
                   <Checkbox
-                    onChange={() => checkSingleLabel(l.id)}
+                    onChange={() =>
+                      checkSingleLabel(
+                        l.id,
+                        l.devices.reduce((result, device) => {
+                          if (device.config_profile_id) {
+                            result.push(device.config_profile_id);
+                          }
+                          return result;
+                        }, [])
+                      )
+                    }
                     checked={checkedLabels[l.id]}
                   >
                     {l.name}

--- a/assets/js/graphql/labels.js
+++ b/assets/js/graphql/labels.js
@@ -34,10 +34,14 @@ export const ALL_LABELS_DEVICES = gql`
       id
       name
       device_count
+      devices {
+        config_profile_id
+      }
     }
     allDevices {
       id
       name
+      config_profile_id
     }
   }
 `;
@@ -52,6 +56,7 @@ export const ALL_LABELS = gql`
         id
         in_xor_filter
       }
+      config_profile_id
     }
   }
 `;


### PR DESCRIPTION
Display a confirmation modal when attempting to add a label if the device has a profile set and so does the label (but profiles are different).

<img width="715" alt="Screen Shot 2021-10-06 at 9 42 44 AM" src="https://user-images.githubusercontent.com/51131939/136247417-8a36aad7-988d-4eea-8002-e8f409fb0776.png">

To test:
- Add a profile to a label
- Add a different profile to a device
- Add label to the device
- Confirmation modal should appear
(Also can test multiple devices at a time)