### PR TITLE
Prevent double counting with slow event runs

### DIFF
--- a/lib/console_web/channels/monitor.ex
+++ b/lib/console_web/channels/monitor.ex
@@ -4,10 +4,18 @@ defmodule ConsoleWeb.Monitor do
   end
 
   def get_router_address do
-    Agent.get(__MODULE__, fn state -> state end)
+    Agent.get(__MODULE__, fn state -> Map.get(state, :address, "") end)
   end
 
   def update_router_address(address) do
-    Agent.update(__MODULE__, fn _ -> address end)
+    Agent.update(__MODULE__, fn state -> Map.put(state, :address, address) end)
+  end
+
+  def get_event_stat_running?() do
+    Agent.get(__MODULE__, fn state -> Map.get(state, :running_stats, false) end)
+  end
+
+  def set_event_stat_running(status) do
+    Agent.update(__MODULE__, fn state -> Map.put(state, :running_stats, status) end)
   end
 end


### PR DESCRIPTION
Since we run every 5 seconds, in the off chance that a run takes longer than 5 seconds, prevent the later run from running and double counting.