### PR TITLE
Round RSSI avg value on Coverage pages

### DIFF
--- a/assets/js/components/coverage/SignalIcon.jsx
+++ b/assets/js/components/coverage/SignalIcon.jsx
@@ -26,7 +26,7 @@ export default ({ rssi }) => {
   const content = (
     <>
       <b>{strength} Signal</b>
-      {rssi && <div>Avg {rssi}dBm</div>}
+      {rssi && <div>Avg {(Math.round(rssi * 100) / 100).toFixed(2)}dBm</div>}
     </>
   );
 


### PR DESCRIPTION
Sometimes the RSSI value spills over outside of the popover.

![image](https://user-images.githubusercontent.com/51131939/146086891-2c5205a0-49c5-48ad-b430-90ccd24cde1d.png)

Round to 2 decimals to avoid this.
![image](https://user-images.githubusercontent.com/51131939/146086916-46136b94-47aa-4ff9-8ea0-fb109e8bdc82.png)
