### PR TITLE
Ignore router GET device when ID is unknown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ data/
 /.env
 /.env-router
 docker-compose.yaml
+nginx.conf

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -44,7 +44,8 @@ config :appsignal, :config,
   active: true,
   name: System.get_env("APPSIGNAL_APP_NAME"),
   push_api_key: System.get_env("APPSIGNAL_API_KEY"),
-  env: Mix.env
+  env: Mix.env,
+  ignore_actions: ["ConsoleWeb.Router.DeviceController#get_by_other_creds"]
 
 config :console,
   stripe_secret_key: System.get_env("STRIPE_SECRET_KEY")

--- a/lib/console_web/controllers/router/device_controller.ex
+++ b/lib/console_web/controllers/router/device_controller.ex
@@ -46,7 +46,7 @@ defmodule ConsoleWeb.Router.DeviceController do
     |> send_resp(:ok, Poison.encode!(response))
   end
 
-  def show(conn, %{"id" => _, "dev_eui" => dev_eui, "app_eui" => app_eui}) do
+  def get_by_other_creds(conn, %{"dev_eui" => dev_eui, "app_eui" => app_eui}) do
     devices = Devices.get_by_dev_eui_app_eui(dev_eui, app_eui)
 
     render(conn, "devices.json", devices: devices)

--- a/lib/console_web/router.ex
+++ b/lib/console_web/router.ex
@@ -116,7 +116,9 @@ defmodule ConsoleWeb.Router do
   scope "/api/router", ConsoleWeb.Router do
     pipe_through ConsoleWeb.RouterApiPipeline
 
-    resources "/devices", DeviceController, only: [:index, :show] do
+    get "/devices/unknown", DeviceController, :get_by_other_creds
+    get "/devices/:id", DeviceController, :show
+    resources "/devices", DeviceController, only: [:index] do
       post "/event", DeviceController, :add_device_event
     end
     post "/devices/update_in_xor_filter", DeviceController, :update_devices_in_xor_filter

--- a/test/console_web/controllers/router/router_device_controller_test.exs
+++ b/test/console_web/controllers/router/router_device_controller_test.exs
@@ -14,12 +14,12 @@ defmodule ConsoleWeb.RouterDeviceControllerTest do
       organization = insert(:organization)
       device_0 = insert(:device, %{ organization_id: organization.id, dev_eui: "1111111111111111", app_eui: "1111111111111111", app_key: "11111111111111111111111111111111" })
 
-      resp_conn = build_conn() |> get("/api/router/devices/yolo?app_eui=#{device_0.app_eui}&dev_eui=#{device_0.dev_eui}")
+      resp_conn = build_conn() |> get("/api/router/devices/unknown?app_eui=#{device_0.app_eui}&dev_eui=#{device_0.dev_eui}")
       assert response(resp_conn, 401) # unauthenticated
 
       resp_conn = build_conn()
         |> put_req_header("authorization", "Bearer " <> jwt)
-        |> get("/api/router/devices/yolo?app_eui=#{device_0.app_eui}&dev_eui=#{device_0.dev_eui}")
+        |> get("/api/router/devices/unknown?app_eui=#{device_0.app_eui}&dev_eui=#{device_0.dev_eui}")
       devices_json = json_response(resp_conn, 200)
       assert devices_json |> length() == 1
       assert devices_json |> List.first() |> Map.get("id") == device_0.id


### PR DESCRIPTION
```
➜  console git:(appsignal) ✗ mix test

14:45:41.547 [info]  Migrations already up
............................................................

Finished in 1.8 seconds (0.4s async, 1.4s sync)
60 tests, 0 failures
```