### PR TITLE
Add device info to integration stopped working alert

### DIFF
--- a/lib/console_web/controllers/router/device_controller.ex
+++ b/lib/console_web/controllers/router/device_controller.ex
@@ -613,10 +613,13 @@ defmodule ConsoleWeb.Router.DeviceController do
 
         if event.data["integration"]["status"] != "success" do
           { _, time } = Timex.format(reported_at_naive, "%H:%M:%S UTC", :strftime)
+          device = Devices.get_device!(event.device_id)
           details = %{
             channel_name: event_integration.name,
             channel_id: event_integration.id,
-            time: time
+            time: time,
+            device_name: device.name,
+            device_id: device.id
           }
           limit = %{ time_buffer: Timex.shift(Timex.now, hours: -1) }
           AlertEvents.notify_alert_event(event_integration.id, "integration", "integration_stops_working", details, nil, limit)

--- a/lib/console_web/templates/email/integration_stops_working_notification_email.html.eex
+++ b/lib/console_web/templates/email/integration_stops_working_notification_email.html.eex
@@ -243,13 +243,13 @@
                     <h1 style="margin: 0 0 30px; font-size: 30px; line-height: 30px; font-weight: normal; ">Alert: <%= @alert_name %></h1>
                     <div style="margin: 0">
                       <%= if @num_channels == 1 do %>
-                        The Integration <b><%= List.first(@details)["channel_name"] %></b> that belongs to the Organization <b><%= @organization_name %></b> has stopped working at <b><%= List.first(@details)["time"] %></b>.
+                        The Integration <b><%= List.first(@details)["channel_name"] %></b> that belongs to the Organization <b><%= @organization_name %></b> has stopped working at <b><%= List.first(@details)["time"] %></b> on your Device, <b><a target="_blank" href="<%= @url <> "/devices/" <> List.first(@details)["device_id"] %>"><%= List.first(@details)["device_name"] %></a></b>.
                       <% end %>
                       <%= if @num_channels > 1 && @num_channels <= 5 do %>
                         The following Integrations that belong to the Organization <b><%= @organization_name %></b> have stopped working:
                         <ul>
                           <%= Enum.map(@details, fn(d) -> %>
-                            <li><b><%= d["channel_name"] %></b>, at <b><%= d["time"] %></b>
+                            <li><b><%= d["channel_name"] %></b>, at <b><%= d["time"] %></b> on Device <b><a target="_blank" href="<%= @url <> "/devices/" <> d["device_id"] %>"><%= d["device_name"] %></a></b>
                           <% end) %>
                         </ul>
                       <% end %>

--- a/lib/console_web/templates/email/integration_stops_working_notification_email.text.eex
+++ b/lib/console_web/templates/email/integration_stops_working_notification_email.text.eex
@@ -1,12 +1,12 @@
 Alert: <%= @alert_name %>
 
 <%= if @num_channels == 1 do %>
-  The Integration <%= List.first(@details)["channel_name"] %> that belongs to the Organization <%= @organization_name %> has stopped working at <%= List.first(@details)["time"] %>.
+  The Integration <%= List.first(@details)["channel_name"] %> that belongs to the Organization <%= @organization_name %> has stopped working at <%= List.first(@details)["time"] %> on your Device, <%= List.first(@details)["device_name"] %>.
 <% end %>
 <%= if @num_channels > 1 && @num_channels <= 5 do %>
   The following Organization <%= @organization_name %> Integrations have stopped working:
   <%= Enum.map(@details, fn(d) -> %>
-    <%= d["channel_name"] %>, at <%= d["time"] %>
+    <%= d["channel_name"] %>, at <%= d["time"] %> on Device <%= d["device_name"] %>
   <% end) %>
 <% end %>
 <%= if @num_channels > 5 do %>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/51131939/153982292-1fc70eea-e306-40c5-a331-f00d6a7dea1b.png)

So this alert can be more helpful, it now includes the device name (with a link to it on console).

```
➜  console git:(dev) ✗ mix test
Compiling 18 files (.ex)

19:39:25.665 [info]  Migrations already up
......................................................................

Finished in 2.0 seconds (0.5s async, 1.4s sync)
70 tests, 0 failures
```