### PR TITLE
Fix grabbing env for audit action

### DIFF
--- a/lib/console/audit_actions/audit_actions.ex
+++ b/lib/console/audit_actions/audit_actions.ex
@@ -14,7 +14,7 @@ defmodule Console.AuditActions do
         "data" => data
       }
 
-    if Mix.env != :test do
+    if Application.get_env(:console, :env) != :test do
       Task.Supervisor.async_nolink(ConsoleWeb.TaskSupervisor, fn ->
         %AuditAction{}
         |> AuditAction.create_changeset(attrs)


### PR DESCRIPTION
`Mix.env` does not work in stg environment and thus every time `create_audit_action` was called, it was erroring out with:
```
** (exit) an exception was raised:
    ** (UndefinedFunctionError) function Mix.env/0 is undefined (module Mix is not available)
        Mix.env()
```