### PR TITLE
Small fixes for Coverage

### DIFF
--- a/assets/js/components/coverage/CoverageIndex.jsx
+++ b/assets/js/components/coverage/CoverageIndex.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useSelector } from "react-redux";
 import DashboardLayout from "../common/DashboardLayout";
-import { MobileDisplay, DesktopDisplay } from '../mobile/MediaQuery'
+import { MobileDisplay, DesktopDisplay } from "../mobile/MediaQuery";
 import { useQuery, useLazyQuery } from "@apollo/client";
 import {
   HOTSPOT_STATS,
@@ -77,6 +77,7 @@ export default (props) => {
     },
   ] = useLazyQuery(SEARCH_HOTSPOTS, {
     fetchPolicy: "cache-and-network",
+    notifyOnNetworkStatusChange: true,
   });
 
   const [

--- a/assets/js/components/coverage/CoverageSearchTable.jsx
+++ b/assets/js/components/coverage/CoverageSearchTable.jsx
@@ -43,7 +43,7 @@ export default ({
         }}
       >
         <Select
-          value={`${hotspots.pageSize} results`}
+          value={`${hotspots.pageSize ? hotspots.pageSize : 0} results`}
           onSelect={handleChangePageSize}
           style={{ marginRight: 40, paddingTop: 2 }}
         >


### PR DESCRIPTION
- Previously, when the search was loading, it would show NULL in the pagination dropdown
- Sometimes when refetching results with search, loading wouldn't be true unless the prop is added to show loading on network status change