### PR TITLE
Increase multibuy to 16

### DIFF
--- a/assets/js/components/multi_buy/MultiBuyForm.jsx
+++ b/assets/js/components/multi_buy/MultiBuyForm.jsx
@@ -136,7 +136,7 @@ export default ({ show, id, openDeleteMultiplePacketModal }) => {
                   <Slider
                     value={multiBuyValue}
                     min={1}
-                    max={10}
+                    max={17}
                     tooltipVisible={false}
                     onChange={(value) => setMultiBuyValue(value)}
                     disabled={!userCan({ role: currentRole })}
@@ -146,9 +146,9 @@ export default ({ show, id, openDeleteMultiplePacketModal }) => {
                 <p style={{ color: "#096DD9", fontSize: 18, fontWeight: 600 }}>
                   {(!multiBuyValue || multiBuyValue == 1) && "Just 1 Packet"}
                   {multiBuyValue > 1 &&
-                    multiBuyValue < 10 &&
+                    multiBuyValue < 17 &&
                     `Up to ${multiBuyValue} Packets`}
-                  {multiBuyValue == 10 && `All Available Packets`}
+                  {multiBuyValue == 17 && `All Available Packets`}
                 </p>
               </div>
 

--- a/assets/js/components/multi_buy/MultiBuyIndexTable.jsx
+++ b/assets/js/components/multi_buy/MultiBuyIndexTable.jsx
@@ -18,7 +18,7 @@ export default (props) => {
     {
       title: "Multiple Packet Value",
       dataIndex: "value",
-      render: (data) => (data === 10 ? "All Available" : "Up to " + data),
+      render: (data) => (data === 17 ? "All Available" : "Up to " + data),
     },
     {
       title: "",

--- a/lib/console/multi_buys/multi_buy.ex
+++ b/lib/console/multi_buys/multi_buy.ex
@@ -29,7 +29,7 @@ defmodule Console.MultiBuys.MultiBuy do
     |> validate_required(:name, message: "Name cannot be blank")
     |> validate_length(:name, min: 3, message: "Name must be at least 3 characters")
     |> validate_length(:name, max: 25, message: "Name cannot be longer than 25 characters")
-    |> validate_number(:value, greater_than: 0, less_than: 11)
+    |> validate_number(:value, greater_than: 0, less_than: 18)
     |> unique_constraint(:name, name: :multi_buys_name_organization_id_index, message: "This name has already been used in this organization")
   end
 end

--- a/lib/console_web/controllers/router/device_controller.ex
+++ b/lib/console_web/controllers/router/device_controller.ex
@@ -84,7 +84,7 @@ defmodule ConsoleWeb.Router.DeviceController do
             0 ->
               case device.multi_buy_id do
                 nil -> 1
-                _ -> if device.multi_buy.value == 10, do: 9999, else: device.multi_buy.value
+                _ -> if device.multi_buy.value == 17, do: 9999, else: device.multi_buy.value
               end
             _ ->
               label_multi_buys =
@@ -97,13 +97,13 @@ defmodule ConsoleWeb.Router.DeviceController do
                 0 ->
                   case device.multi_buy_id do
                     nil -> 1
-                    _ -> if device.multi_buy.value == 10, do: 9999, else: device.multi_buy.value
+                    _ -> if device.multi_buy.value == 17, do: 9999, else: device.multi_buy.value
                   end
                 _ ->
                   max_value = Enum.max(label_multi_buys)
                   case device.multi_buy_id do
-                    nil -> if max_value == 10, do: 9999, else: max_value
-                    _ -> if device.multi_buy.value == 10, do: 9999, else: device.multi_buy.value
+                    nil -> if max_value == 17, do: 9999, else: max_value
+                    _ -> if device.multi_buy.value == 17, do: 9999, else: device.multi_buy.value
                   end
               end
           end


### PR DESCRIPTION
This pull request increases the maximum number of packets that can be bought to 16.  
This is useful for RSSI location services like Semtech's [LoRa Cloud](https://www.loracloud.com/) where the accuracy is increased when you send up to 16 packets. Today one needs to buy all available packets to benefit of this but it can quickly become expensive for example in the Bay area where a packet is received by 300 or 400 gateways...

The change
![image](https://user-images.githubusercontent.com/6248122/160366105-cd017af0-11b7-4bd1-b130-d994abaf8850.png)

Example of location, in yellow the RSSI loc when buying 9 packets
![image](https://user-images.githubusercontent.com/6248122/160368210-5763521e-8b8d-45cf-8644-65c95ef6a4d0.png)
