### PR TITLE
Add hotspot syncing task for Heroku Scheduler

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -85,15 +85,18 @@ config :console, Console.Scheduler,
     ],
     sync_hotspots_1: [
       schedule: "0 2 * * *", # every day at 2am utc
-      task: {Console.Jobs, :sync_hotspots, []}
+      task: {Console.Jobs, :sync_hotspots, []},
+      state: (if System.get_env("USE_SCHEDULER_FOR_HOTSPOT_SYNC"), do: :inactive, else: :active)
     ],
     sync_hotspots_2: [
       schedule: "0 6 * * *", # every day at 6am utc
-      task: {Console.Jobs, :sync_hotspots, []}
+      task: {Console.Jobs, :sync_hotspots, []},
+      state: (if System.get_env("USE_SCHEDULER_FOR_HOTSPOT_SYNC"), do: :inactive, else: :active)
     ],
     sync_hotspots_3: [
       schedule: "0 10 * * *", # every day at 10am utc
-      task: {Console.Jobs, :sync_hotspots, []}
+      task: {Console.Jobs, :sync_hotspots, []},
+      state: (if System.get_env("USE_SCHEDULER_FOR_HOTSPOT_SYNC"), do: :inactive, else: :active)
     ],
   ]
 

--- a/lib/mix/tasks/sync_hotspots.ex
+++ b/lib/mix/tasks/sync_hotspots.ex
@@ -1,0 +1,10 @@
+defmodule Mix.Tasks.SyncHotspots do
+  use Mix.Task
+  alias Console.Jobs
+
+  def run(_) do
+    IO.inspect "Syncing hotspots from public API"
+    Mix.Task.run("app.start")
+    Jobs.sync_hotspots()
+  end
+end

--- a/lib/mix/tasks/sync_hotspots.ex
+++ b/lib/mix/tasks/sync_hotspots.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.SyncHotspots do
   alias Console.Jobs
 
   def run(_) do
-    IO.inspect "Syncing hotspots from public API"
+    IO.inspect "Starting to sync hotspots..."
     Mix.Task.run("app.start")
     Jobs.sync_hotspots()
   end


### PR DESCRIPTION
This PR enables us to use a Mix task ran by the Heroku scheduler for certain environments (prod and dedicated). When `USE_SCHEDULER_FOR_HOTSPOT_SYNC` is set for the environment, it will inactivate the Quantum scheduler jobs in the app (which we still want for other environments such as stg).