### PR TITLE
Hotspots indexes

### DIFF
--- a/priv/repo/migrations/20220523222451_hotspots_table_indexes.exs
+++ b/priv/repo/migrations/20220523222451_hotspots_table_indexes.exs
@@ -1,0 +1,8 @@
+defmodule Console.Repo.Migrations.HotspotsTableIndexes do
+  use Ecto.Migration
+
+  def change do
+    create index(:hotspots, [:name])
+    create index(:hotspots, [:long_city])
+  end
+end


### PR DESCRIPTION
AppSignal errors:
`ERROR 57014 (query_canceled) canceling statement due to user request`
Trace:
```
{
  "operationName": "paginatedSearchHotspotsQuery",
  "query": "query paginatedSearchHotspotsQuery($query: String, $page: Int, $pageSize: Int, $column: String, $order: String) {\n  searchHotspots(\n    query: $query\n    page: $page\n    pageSize: $pageSize\n    column: $column\n    order: $order\n  ) {\n    entries {\n      hotspot_address\n      hotspot_name\n      long_city\n      short_state\n      short_country\n      status\n      packet_count\n      packet_count_2d\n      device_count\n      device_count_2d\n      longitude\n      latitude\n      __typename\n    }\n    totalEntries\n    totalPages\n    pageSize\n    pageNumber\n    __typename\n  }\n}\n",
  "variables": {
    "column": "hotspot_name",
    "order": "asc",
    "page": 3580,
    "pageSize": 10,
    "query": "oxford"
  }
}
```

we currently query the hotspots table on `name`, `long_city`, and `owner` (we already have an index for the latter). here's the result of testing two new indexes (on dev): 

before:
```
Planning Time: 1.368 ms
Execution Time: 12962.903 ms
```

after:
```
 Planning Time: 0.770 ms
 Execution Time: 11616.421 ms
```