### PR TITLE
Fix packet config doc link

### DIFF
--- a/assets/js/components/packet_configs/PacketConfigForm.jsx
+++ b/assets/js/components/packet_configs/PacketConfigForm.jsx
@@ -127,7 +127,7 @@ export default ({
             <p>
               <a
                 className="help-link"
-                href="https://docs.helium.com/use-the-network/console/packets"
+                href="https://docs.helium.com/use-the-network/console/multi-packets/"
                 target="_blank"
               >
                 Learn more about Packet Configurations


### PR DESCRIPTION
This PR fixes the packet configuration documentation link.
The current broken link is seen at the following url: https://console.helium.com/packets/new

<img width="1136" alt="Screen Shot 2022-06-21 at 9 44 48 PM" src="https://user-images.githubusercontent.com/35268630/174925584-a32f15ab-a10e-4444-84d2-6d7ffe2834c9.png">
