### PR TITLE
Refactor coverage search

### DIFF
--- a/assets/js/components/coverage/Constants.js
+++ b/assets/js/components/coverage/Constants.js
@@ -270,7 +270,9 @@ export const getColumns = (
         (c) =>
           c.dataIndex !== "alias" &&
           c.dataIndex !== "group_ids" &&
-          c.dataIndex !== "avg_rssi"
+          c.dataIndex !== "avg_rssi" &&
+          c.dataIndex !== "packet_count" &&
+          c.dataIndex !== "device_count"
       );
     case "main":
       return columns.filter((c) => c.dataIndex !== "group_ids");

--- a/assets/js/components/coverage/CoverageSearchTab.jsx
+++ b/assets/js/components/coverage/CoverageSearchTab.jsx
@@ -168,6 +168,13 @@ export default ({ searchHotspots, data, error, loading, ...props }) => {
             value={term}
           />
         </div>
+        {
+          term.length > 0 && term.length < 3 && (
+            <div style={{ marginTop: 4, marginLeft: 15 }}>
+              <Text style={{ color: '#F5222D'}}>Search term must be 3 or more characters</Text>
+            </div>
+          )
+        }
 
         {searchTerm.length === 0 && (
           <Row gutter={24} style={{ marginTop: 20 }}>
@@ -264,7 +271,7 @@ export default ({ searchHotspots, data, error, loading, ...props }) => {
             hotspots={
               data
                 ? data.searchHotspots
-                : { entries: [], pageSize: 10, page: 1, totalEntries: 0 }
+                : { entries: [], pageSize, page: 1, totalEntries: 0 }
             }
             handleChangePageSize={handleChangePageSize}
             handleSortChange={handleSortChange}

--- a/lib/console/search/search.ex
+++ b/lib/console/search/search.ex
@@ -384,7 +384,7 @@ defmodule Console.Search do
   end
 
   # running for owner wallet address search
-  def run_for_hotspots(query, page, page_size, column, order) when byte_size(query) > 50 and byte_size(query) < 53 do
+  def run_for_hotspots(query, page, page_size, column, order) when String.match?(query, ~r/^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{51,52}$/) do
     order_by = case [column, order] do
       [nil, nil] -> [desc: :name]
       _ -> [String.to_existing_atom(Helpers.order_with_nulls(order)), String.to_existing_atom(column)]

--- a/lib/console/search/search.ex
+++ b/lib/console/search/search.ex
@@ -384,7 +384,7 @@ defmodule Console.Search do
   end
 
   # running for owner wallet address search
-  def run_for_hotspots(query, page, page_size, column, order) when String.match?(query, ~r/^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{51,52}$/) do
+  def run_for_hotspots(query, page, page_size, column, order) when String.match?(query, ~r/^[1-9A-HJ-NP-Za-km-z]{51,52}$/) do
     order_by = case [column, order] do
       [nil, nil] -> [desc: :name]
       _ -> [String.to_existing_atom(Helpers.order_with_nulls(order)), String.to_existing_atom(column)]

--- a/lib/console/search/search.ex
+++ b/lib/console/search/search.ex
@@ -383,18 +383,14 @@ defmodule Console.Search do
     %{}
   end
 
-  def run_for_hotspots(query, page, page_size, column, order) when byte_size(query) < 3 do
+  # running for owner wallet address search
+  def run_for_hotspots(query, page, page_size, column, order) when byte_size(query) > 50 and byte_size(query) < 53 do
     order_by = case [column, order] do
-      [nil, nil] -> [desc: :score]
-      _ -> [{String.to_existing_atom(Helpers.order_with_nulls(order)), String.to_existing_atom(column)}, {:desc, :score}, ]
+      [nil, nil] -> [desc: :name]
+      _ -> [String.to_existing_atom(Helpers.order_with_nulls(order)), String.to_existing_atom(column)]
     end
 
-    current_unix = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
-    unix1d = current_unix - 86400000
-    unix2d = current_unix - 86400000 * 2
-
-    sub_query_1 = from h in Hotspot,
-      where: ilike(h.name, ^"%#{query}%") or ilike(h.long_city, ^"%#{query}%"),
+    query = from h in Hotspot,
       select: %{
         hotspot_address: h.address,
         hotspot_name: h.name,
@@ -403,36 +399,11 @@ defmodule Console.Search do
         short_country: h.short_country,
         status: h.status,
         longitude: h.lng,
-        latitude: h.lat,
-        score: 1.0,
-        packet_count: fragment("SELECT COUNT(*) FROM hotspot_stats WHERE hotspot_address = ? AND reported_at_epoch > ?", h.address, ^unix1d),
-        packet_count_2d: fragment("SELECT COUNT(*) FROM hotspot_stats WHERE hotspot_address = ? AND reported_at_epoch < ? AND reported_at_epoch > ?", h.address, ^unix1d, ^unix2d),
-        device_count: fragment("SELECT COUNT(DISTINCT(device_id)) FROM hotspot_stats WHERE hotspot_address = ? AND reported_at_epoch > ?", h.address, ^unix1d),
-        device_count_2d: fragment("SELECT COUNT(DISTINCT(device_id)) FROM hotspot_stats WHERE hotspot_address = ? AND reported_at_epoch < ? AND reported_at_epoch > ?", h.address, ^unix1d, ^unix2d)
-      }
+        latitude: h.lat
+      },
+      where: h.owner == ^query,
+      order_by: ^order_by
 
-    sub_query_2 = from h in Hotspot,
-      where: ilike(h.name, ^"%#{query}%") or ilike(h.long_city, ^"%#{query}%"),
-      select: %{
-        hotspot_address: h.address,
-        hotspot_name: h.name,
-        long_city: h.long_city,
-        short_state: h.short_state,
-        short_country: h.short_country,
-        status: h.status,
-        longitude: h.lng,
-        latitude: h.lat,
-        score: 0.5,
-        packet_count: fragment("SELECT COUNT(*) FROM hotspot_stats WHERE hotspot_address = ? AND reported_at_epoch > ?", h.address, ^unix1d),
-        packet_count_2d: fragment("SELECT COUNT(*) FROM hotspot_stats WHERE hotspot_address = ? AND reported_at_epoch < ? AND reported_at_epoch > ?", h.address, ^unix1d, ^unix2d),
-        device_count: fragment("SELECT COUNT(DISTINCT(device_id)) FROM hotspot_stats WHERE hotspot_address = ? AND reported_at_epoch > ?", h.address, ^unix1d),
-        device_count_2d: fragment("SELECT COUNT(DISTINCT(device_id)) FROM hotspot_stats WHERE hotspot_address = ? AND reported_at_epoch < ? AND reported_at_epoch > ?", h.address, ^unix1d, ^unix2d)
-      }
-
-    main_subquery = from q in subquery(union(sub_query_1, ^sub_query_2)), distinct: q.hotspot_address, order_by: [desc: q.hotspot_address, desc: q.score]
-    
-    query = from h in subquery(main_subquery), order_by: ^order_by
-    
     query |> Repo.paginate(page: page, page_size: page_size)
   end
 
@@ -441,10 +412,6 @@ defmodule Console.Search do
       [nil, nil] -> [desc: :score]
       _ -> [{String.to_existing_atom(Helpers.order_with_nulls(order)), String.to_existing_atom(column)}, {:desc, :score}]
     end
-
-    current_unix = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
-    unix1d = current_unix - 86400000
-    unix2d = current_unix - 86400000 * 2
 
     sub_query = from h in Hotspot,
       select: %{
@@ -462,13 +429,9 @@ defmodule Console.Search do
           h.name, ^query,
           h.long_city, ^query
         ),
-        owner: h.owner,
-        packet_count: fragment("SELECT COUNT(*) FROM hotspot_stats WHERE hotspot_address = ? AND reported_at_epoch > ?", h.address, ^unix1d),
-        packet_count_2d: fragment("SELECT COUNT(*) FROM hotspot_stats WHERE hotspot_address = ? AND reported_at_epoch < ? AND reported_at_epoch > ?", h.address, ^unix1d, ^unix2d),
-        device_count: fragment("SELECT COUNT(DISTINCT(device_id)) FROM hotspot_stats WHERE hotspot_address = ? AND reported_at_epoch > ?", h.address, ^unix1d),
-        device_count_2d: fragment("SELECT COUNT(DISTINCT(device_id)) FROM hotspot_stats WHERE hotspot_address = ? AND reported_at_epoch < ? AND reported_at_epoch > ?", h.address, ^unix1d, ^unix2d)
+        owner: h.owner
       }
-    
+
     query = from d in subquery(sub_query), select: %{
       hotspot_address: d.hotspot_address,
       hotspot_name: d.hotspot_name,
@@ -478,13 +441,9 @@ defmodule Console.Search do
       status: d.status,
       score: d.score,
       longitude: d.longitude,
-      latitude: d.latitude,
-      packet_count: d.packet_count,
-      packet_count_2d: d.packet_count_2d,
-      device_count: d.device_count,
-      device_count_2d: d.device_count_2d
+      latitude: d.latitude
     },
-    where: d.score > @sim_limit or d.owner == ^query,
+    where: d.score > @sim_limit,
     order_by: ^order_by
 
     query |> Repo.paginate(page: page, page_size: page_size)


### PR DESCRIPTION
Refactoring coverage search for better performance.

1. Removed device and packet stats from search results as it makes the query too long and complicated. Also, if a hotspot has transferred data for the org, it will already show up in the main coverage tab.
2. Removed query searches for length < 3, these queries are useless
3. Queries clearly meant for owner wallet search should be optimized