### PR TITLE
Gracefully handle when Magic fails to get user metadata

### DIFF
--- a/assets/js/actions/auth.js
+++ b/assets/js/actions/auth.js
@@ -1,72 +1,80 @@
-import * as rest from '../util/rest';
-import { intercomResizeListen } from '../util/intercom'
-import { logout } from '../components/auth/Auth0Provider';
-import { logoutUser } from './magic'
-import analyticsLogger from '../util/analyticsLogger';
-import { config } from '../config/magic'
-import crypto from "crypto"
+import * as rest from "../util/rest";
+import { intercomResizeListen } from "../util/intercom";
+import { logout } from "../components/auth/Auth0Provider";
+import { logoutUser } from "./magic";
+import analyticsLogger from "../util/analyticsLogger";
+import { config } from "../config/magic";
+import crypto from "crypto";
+import { displayError } from "../util/messages";
 
-export const SET_MAGIC_USER = 'SET_MAGIC_USER';
-export const CLEAR_MAGIC_USER = 'CLEAR_MAGIC_USER';
+export const SET_MAGIC_USER = "SET_MAGIC_USER";
+export const CLEAR_MAGIC_USER = "CLEAR_MAGIC_USER";
 
 export const getMfaStatus = () => {
   return (dispatch) => {
-    return rest.get('/api/mfa_enrollments');
-  }
-}
+    return rest.get("/api/mfa_enrollments");
+  };
+};
 
 export const enrollInMfa = () => {
   return (dispatch) => {
-    return rest.post('/api/mfa_enrollments');
-  }
-}
+    return rest.post("/api/mfa_enrollments");
+  };
+};
 
 export const disableMfa = () => {
   return (dispatch) => {
-    return rest.destroy('/api/mfa_enrollments');
-  }
-}
+    return rest.destroy("/api/mfa_enrollments");
+  };
+};
 
 export const logOut = () => {
-  analyticsLogger.setUserId(null)
-  window.Intercom('shutdown')
+  analyticsLogger.setUserId(null);
+  window.Intercom("shutdown");
 
   return async (dispatch) => {
     localStorage.removeItem("organization");
     if (config.useMagicAuth) {
-      await logoutUser()
-      dispatch(clearMagicUser())
-      window.location.replace("/")
+      await logoutUser();
+      dispatch(clearMagicUser());
+      window.location.replace("/");
     } else {
-      await logout({returnTo: window.location.origin});
+      await logout({ returnTo: window.location.origin });
     }
-  }
-}
+  };
+};
 
 export const subscribeNewUser = (email) => {
   return (dispatch) => {
-    rest.post(`/api/subscribe_new_user`, { email })
-    .then(() => {})
-  }
-}
+    rest.post(`/api/subscribe_new_user`, { email }).then(() => {});
+  };
+};
 
 export const magicLogIn = (user) => {
-  const hash = crypto.createHmac('sha256', process.env.INTERCOM_ID_SECRET || 'key').update(user.email).digest('hex')
-  window.Intercom('boot', {
-    app_id: 'uj330shp',
-    email: user.email,
-    user_hash: hash
-  })
-  intercomResizeListen()
+  if (user.email) {
+    const hash = crypto
+      .createHmac("sha256", process.env.INTERCOM_ID_SECRET || "key")
+      .update(user.email)
+      .digest("hex");
+    window.Intercom("boot", {
+      app_id: "uj330shp",
+      email: user.email,
+      user_hash: hash,
+    });
+    intercomResizeListen();
 
-  return {
-    type: SET_MAGIC_USER,
-    payload: user
+    return {
+      type: SET_MAGIC_USER,
+      payload: user,
+    };
+  } else {
+    displayError("Something went wrong. Please try logging in again.");
+    logOut();
   }
-}
+};
 
 export const clearMagicUser = () => {
   return {
     type: CLEAR_MAGIC_USER,
-  }
-}
+  };
+};

--- a/assets/js/actions/magic.js
+++ b/assets/js/actions/magic.js
@@ -1,100 +1,131 @@
-import { Magic } from 'magic-sdk';
-import { OAuthExtension } from '@magic-ext/oauth';
-import { displayError } from '../util/messages'
-import { store } from '../store/configureStore';
-import { magicLogIn, logOut } from './auth'
+import { Magic } from "magic-sdk";
+import { OAuthExtension } from "@magic-ext/oauth";
+import { displayError } from "../util/messages";
+import { store } from "../store/configureStore";
+import { magicLogIn, logOut } from "./auth";
 
-export const magic = new Magic(window.magic_public_key || process.env.MAGIC_PUBLIC_KEY || 'pk_live_3EE671255ACEC2E5', {
-  extensions: [new OAuthExtension()],
-});
+export const magic = new Magic(
+  window.magic_public_key ||
+    process.env.MAGIC_PUBLIC_KEY ||
+    "pk_live_3EE671255ACEC2E5",
+  {
+    extensions: [new OAuthExtension()],
+  }
+);
 
 export const checkUser = async () => {
-  const isLoggedIn = await magic.user.isLoggedIn();
-  if (isLoggedIn) {
-    const user = await magic.user.getMetadata();
-    let needRegistration = false
-    if (window.user_invite_only === 'true' || process.env.USER_INVITE_ONLY === 'true') {
-      needRegistration = await checkRegisteredUser(user.email)
-    }
+  try {
+    const isLoggedIn = await magic.user.isLoggedIn();
+    if (isLoggedIn) {
+      const user = await magic.user.getMetadata();
+      let needRegistration = false;
+      if (
+        window.user_invite_only === "true" ||
+        process.env.USER_INVITE_ONLY === "true"
+      ) {
+        needRegistration = await checkRegisteredUser(user.email);
+      }
 
-    store.dispatch(magicLogIn({ isLoggedIn: true, email: user.email, sub: user.issuer, needRegistration }))
+      store.dispatch(
+        magicLogIn({
+          isLoggedIn: true,
+          email: user.email,
+          sub: user.issuer,
+          needRegistration,
+        })
+      );
+    }
+  } catch (e) {
+    console.log(e);
   }
 };
 
 export const loginUser = async (email) => {
-  await magic.auth.loginWithMagicLink({ email });
-  const user = await magic.user.getMetadata();
-  let needRegistration = false
-  if (window.user_invite_only === 'true' || process.env.USER_INVITE_ONLY === 'true') {
-    needRegistration = await checkRegisteredUser(user.email)
-  }
+  try {
+    await magic.auth.loginWithMagicLink({ email });
+    const user = await magic.user.getMetadata();
+    let needRegistration = false;
+    if (
+      window.user_invite_only === "true" ||
+      process.env.USER_INVITE_ONLY === "true"
+    ) {
+      needRegistration = await checkRegisteredUser(user.email);
+    }
 
-  store.dispatch(magicLogIn({ isLoggedIn: true, email: user.email, sub: user.issuer, needRegistration }))
+    store.dispatch(
+      magicLogIn({
+        isLoggedIn: true,
+        email: user.email,
+        sub: user.issuer,
+        needRegistration,
+      })
+    );
+  } catch (e) {
+    console.log(e);
+  }
 };
 
 export const loginGoogleUser = async () => {
   await magic.oauth.loginWithRedirect({
-    provider: 'google',
-    redirectURI: new URL('/callback', window.location.origin).href,
+    provider: "google",
+    redirectURI: new URL("/callback", window.location.origin).href,
   });
-}
+};
 
 export const getRedirectResult = async () => {
   await magic.oauth.getRedirectResult();
 
-  const redirectPath = localStorage.getItem('post-google-auth-redirect')
+  const redirectPath = localStorage.getItem("post-google-auth-redirect");
   if (redirectPath) {
-    localStorage.removeItem('post-google-auth-redirect')
-    window.location.replace(redirectPath)
+    localStorage.removeItem("post-google-auth-redirect");
+    window.location.replace(redirectPath);
   } else {
-    window.location.replace("/")
+    window.location.replace("/");
   }
-}
+};
 
 export const logoutUser = async () => {
   await magic.user.logout();
 };
 
 export const getMagicSessionToken = async () => {
-  const didToken = await magic.user.getIdToken()
-  const res =
-    await fetch('/api/sessions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: 'Bearer ' + didToken,
-      },
-    });
+  const didToken = await magic.user.getIdToken();
+  const res = await fetch("/api/sessions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + didToken,
+    },
+  });
 
   if (res.status === 201) {
     const data = await res.json();
-    return data
+    return data;
   } else {
-    displayError()
-    store.dispatch(logOut())
-    return null
+    displayError();
+    store.dispatch(logOut());
+    return null;
   }
-}
+};
 
 const checkRegisteredUser = async (email) => {
-  const didToken = await magic.user.getIdToken()
-  const res =
-    await fetch('/api/sessions/check_user', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: 'Bearer ' + didToken,
-      },
-      body: `{"email":"${email}"}`
-    });
+  const didToken = await magic.user.getIdToken();
+  const res = await fetch("/api/sessions/check_user", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + didToken,
+    },
+    body: `{"email":"${email}"}`,
+  });
 
   if (res.status === 204) {
-    return false
+    return false;
   } else if (res.status === 404) {
-    return true
+    return true;
   } else {
-    displayError()
-    setTimeout(() => store.dispatch(logOut()), 2000)
-    return null
+    displayError();
+    setTimeout(() => store.dispatch(logOut()), 2000);
+    return null;
   }
-}
+};


### PR DESCRIPTION
Currently, when the Magic method for grabbing the user's metadata fails, user sees a loading screen indefinitely. This PR aims to handle this case by logging user out and displaying an error. Currently `console.log`ing the error to see if we can better troubleshoot/debug this issue.